### PR TITLE
chore: fix adoption guide commands + add citation metadata + backfill…

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,28 @@
+{
+  "title": "Neural Computation Protocol (NCP)",
+  "description": "Composable, auditable micro-agent graphs for agentic AI systems. Route cheap deterministic work to WASM Bricks; escalate only when needed.",
+  "license": "Apache-2.0",
+  "access_right": "open",
+  "upload_type": "software",
+  "creators": [
+    {
+      "name": "Salvadori, Fabio Marcello",
+      "affiliation": "Independent"
+    }
+  ],
+  "keywords": [
+    "agentic AI",
+    "WASM",
+    "deterministic execution",
+    "LLM routing",
+    "workflow orchestration",
+    "sandboxing"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/madeinplutofabio/neural-computation-protocol",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,47 @@ All notable changes to the NCP specification and its reference tooling
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Brick versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). NCP protocol versions follow the versioning policy in the spec (v0.2.x patch-compatible, breaking changes require v0.3.0).
 
+## [0.3.3] — 2026-05-XX
+
+### Added
+- **Rust CI workflow** (`.github/workflows/rust.yml`): fmt, clippy with `-D warnings`,
+  cross-platform `cargo test -p ncp-runtime` matrix on pinned OS images
+  (`ubuntu-24.04`, `macos-14`, `windows-2022`); separate `wasm-build` job for
+  brick crates targeting `wasm32-unknown-unknown`; per-job `timeout-minutes`;
+  explicit `permissions:` scope (`contents: read`, `actions: write` for cache);
+  `--locked` on every cargo invocation
+- **Smoke integration tests** (`runtime/tests/smoke.rs`): exercise every runnable
+  example graph end-to-end via `RuntimeContext::load` + `.execute` (in-process,
+  no binary spawn); paths derived from `env!("CARGO_MANIFEST_DIR")` for OS-independent
+  resolution; trap-pipeline assertion accepts any non-empty `error_class` to remain
+  robust across Wasmtime version drift
+- **Citation metadata**: `CITATION.cff` (GitHub "Cite this repository" panel) and
+  `.zenodo.json` (Zenodo archive metadata), both bound to concept DOI
+  `10.5281/zenodo.19570209`
+- **Branch protection**: 6 new Rust CI check contexts required alongside the
+  existing DCO + validate + `wasm-digest-check` set; force-push and branch
+  deletion blocked on `main`; web-based commit sign-off enforced
+- **`docs/BRANCH_PROTECTION.md`**: audit trail for the branch-protection ruleset
+  (current required checks, exact `gh api` command sequence used, rollback
+  procedure, schema-fallback note)
+
+### Fixed
+- `docs/ADOPTION_GUIDE.md`: every `ncp` CLI example now includes the required
+  `run` subcommand (previously copy-pasted commands failed with
+  `unrecognized argument`). `ncp-bench` invocations unaffected (positional graph
+  argument, no subcommand)
+
+## [0.3.2] — 2026-04-14
+
+### Added
+- Apache-2.0 + `NOTICE` + DCO + No-CLA governance finalized
+- Zenodo DOI archive (`10.5281/zenodo.19570209`) via Zenodo's GitHub integration —
+  citable prior art for the protocol, reference runtime, and benchmark methodology
+- DCO enforced as required status check on `main` via branch ruleset
+  "Main Protection"
+- `README.md` finalized: DOI / CI / license / release badges, headline benchmark
+  summary, and "Numbers you can quote" framing
+
 ## [0.3.1] — 2026-04-13
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+
+cff-version: 1.2.0
+message: "If you use NCP in research, please cite it."
+title: "Neural Computation Protocol (NCP)"
+abstract: "Composable, auditable micro-agent graphs for agentic AI systems. Route cheap deterministic work to WASM Bricks; escalate only when needed."
+type: software
+authors:
+  - family-names: Salvadori
+    given-names: Fabio Marcello
+license: Apache-2.0
+repository-code: "https://github.com/madeinplutofabio/neural-computation-protocol"
+version: "0.3.2"
+date-released: "2026-04-14"
+doi: "10.5281/zenodo.19570209"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.19570209"
+    description: "Concept DOI (all versions)"
+keywords:
+  - agentic-ai
+  - wasm
+  - deterministic-execution
+  - llm-routing
+  - workflow-orchestration
+  - sandboxing

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -29,7 +29,7 @@ git clone https://github.com/madeinplutofabio/neural-computation-protocol.git
 cd neural-computation-protocol
 
 # Run the runtime CLI on a known-good example
-cargo run -p ncp-runtime --bin ncp --   examples/graphs/echo-pipeline/graph.yaml   --input examples/graphs/echo-pipeline/sample.json
+cargo run -p ncp-runtime --bin ncp -- run examples/graphs/echo-pipeline/graph.yaml --input examples/graphs/echo-pipeline/sample.json
 ```
 
 You should see a JSON output printed to stdout.
@@ -60,15 +60,15 @@ This graph models a production pattern:
 
 ```bash
 # Positive: no escalation (fast path)
-cargo run -p ncp-runtime --bin ncp --   examples/graphs/support-routing-stubbed/graph.yaml   --input examples/graphs/support-routing-stubbed/sample-positive.json
+cargo run -p ncp-runtime --bin ncp -- run examples/graphs/support-routing-stubbed/graph.yaml --input examples/graphs/support-routing-stubbed/sample-positive.json
 
 # Negative: escalation (slow path)
-cargo run -p ncp-runtime --bin ncp --   examples/graphs/support-routing-stubbed/graph.yaml   --input examples/graphs/support-routing-stubbed/sample.json
+cargo run -p ncp-runtime --bin ncp -- run examples/graphs/support-routing-stubbed/graph.yaml --input examples/graphs/support-routing-stubbed/sample.json
 ```
 
 Optional: show per-step diagnostics
 ```bash
-cargo run -p ncp-runtime --bin ncp --   examples/graphs/support-routing-stubbed/graph.yaml   --input examples/graphs/support-routing-stubbed/sample.json   --verbose
+cargo run -p ncp-runtime --bin ncp -- run examples/graphs/support-routing-stubbed/graph.yaml --input examples/graphs/support-routing-stubbed/sample.json --verbose
 ```
 
 ---
@@ -82,7 +82,7 @@ Tracing emits JSONL records with:
 - result type
 
 ```bash
-cargo run -p ncp-runtime --bin ncp --   examples/graphs/echo-chain/graph.yaml   --input examples/graphs/echo-chain/sample.json   --trace trace.jsonl
+cargo run -p ncp-runtime --bin ncp -- run examples/graphs/echo-chain/graph.yaml --input examples/graphs/echo-chain/sample.json --trace trace.jsonl
 ```
 
 Inspect:
@@ -124,6 +124,8 @@ If you want to call the runtime from your own Rust app (HTTP server, worker, age
 use the library API (`RuntimeContext`) rather than shelling out to the CLI.
 
 ### Example: run a graph in-process
+
+> **Note:** paths below assume your process working directory is the repo root.
 
 ```rust
 use std::path::Path;
@@ -225,4 +227,3 @@ If you want to contribute something *immediately useful*:
 - Roadmap: `docs/ROADMAP.md`
 - Runtime: `runtime/`
 - Examples: `examples/graphs/`
-


### PR DESCRIPTION
… changelog

- docs/ADOPTION_GUIDE.md: insert `run` subcommand in 5 `ncp` CLI examples; ncp-bench invocations unaffected (positional arg, no subcommand). Adds a "paths assume repo root" note above the embed-in-Rust example.
- CITATION.cff (new): CFF v1.2.0 metadata bound to concept DOI 10.5281/zenodo.19570209; version 0.3.2 + date-released 2026-04-14 reflect current released state (PR D will bump on v0.3.3 tag).
- .zenodo.json (new): Zenodo archive metadata for future GitHub releases; access_right: open, license Apache-2.0, related_identifier to repo URL.
- CHANGELOG.md: prepend v0.3.3 stub (Added: Rust CI, smoke tests, citation metadata, branch protection, BRANCH_PROTECTION.md; Fixed: adoption guide `run` subcommand) and backfill missing v0.3.2 entry (governance, Zenodo DOI, DCO required check, README badges/numbers framing).

## What this PR does

## Which spec sections are affected

## Type of change
- [ ] Spec clarification (non-breaking, v0.2.x)
- [ ] Normative change (breaking; requires protocol minor bump, e.g. v0.3.0)
- [ ] Schema update
- [ ] Validator update
- [ ] Documentation
- [ ] Examples

## Checklist
- [ ] I searched existing issues and PRs before opening this one
- [ ] Spec and schemas remain consistent (if one changed, the other was updated)
- [ ] All examples validate green (`npm run validate-examples`)
- [ ] All tests pass (`npm test`)
- [ ] CHANGELOG.md updated
- [ ] Cross-references to spec sections are correct
