### PR TITLE
ci(rust): cross-platform workflow + smoke integration tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+#
+# CI INVARIANTS
+#   - If you rename this workflow's `name:` or any `job:` key below, you MUST
+#     update the branch protection ruleset's required-status-checks list to
+#     match (see docs/BRANCH_PROTECTION.md). Otherwise PRs will block forever
+#     waiting on phantom check contexts.
+#   - NEVER change `-p ncp-runtime` to `--workspace` in the host jobs. The
+#     brick crates are #![no_std] + core::arch::wasm32::* and cannot compile
+#     for host targets.
+
+name: Rust
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: write   # required by Swatinem/rust-cache@v2 (writes to GitHub cache service)
+
+concurrency:
+  group: rust-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# ──────────────────────────────────────────────────────────────────────
+# HOST JOBS (fmt, clippy, test): build runtime crate on host triples.
+# NEVER change `-p ncp-runtime` to `--workspace` — the brick crates are
+# #![no_std] + core::arch::wasm32::* and cannot compile for host targets.
+# ──────────────────────────────────────────────────────────────────────
+jobs:
+  fmt:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    # Host-only lint scope: WASM crates linted in wasm-build job (different target).
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with: { key: clippy }
+      - run: cargo clippy -p ncp-runtime --all-targets --locked -- -D warnings
+
+  test:
+    # Host-only crate scope: -p ncp-runtime avoids attempting to compile
+    # the WASM-only brick crates (no_std + wasm32 intrinsics).
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-14, windows-2022]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25   # Windows runners are consistently slowest; one bound covers all OSes safely.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.os }}
+      - run: cargo test -p ncp-runtime --all-targets --locked
+
+  # ──────────────────────────────────────────────────────────────────────
+  # WASM JOB: build & lint the brick crates for wasm32-unknown-unknown.
+  # Brick crates are LIBRARY targets that can only compile to WASM.
+  # If you find yourself moving these into the host matrix, STOP — they
+  # use core::arch::wasm32::* intrinsics and host compilation will fail.
+  # ──────────────────────────────────────────────────────────────────────
+  wasm-build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+          components: clippy
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with: { key: wasm }
+      - run: cargo build -p ncp-echo --target wasm32-unknown-unknown --release --locked
+      - run: cargo build -p ncp-classifier-stub --target wasm32-unknown-unknown --release --locked
+      - run: cargo clippy -p ncp-echo --target wasm32-unknown-unknown --locked -- -D warnings
+      - run: cargo clippy -p ncp-classifier-stub --target wasm32-unknown-unknown --locked -- -D warnings

--- a/bricks/classifier-stub/src/lib.rs
+++ b/bricks/classifier-stub/src/lib.rs
@@ -141,7 +141,11 @@ fn contains_ci(haystack: &[u8], needle: &[u8]) -> bool {
 }
 
 fn to_lower(b: u8) -> u8 {
-    if b >= b'A' && b <= b'Z' { b + 32 } else { b }
+    if b >= b'A' && b <= b'Z' {
+        b + 32
+    } else {
+        b
+    }
 }
 
 /// Check if text contains any negative keyword.
@@ -228,7 +232,11 @@ pub extern "C" fn alloc(len: i32) -> i32 {
         Err(_) => return 0,
     };
     let ptr = unsafe { alloc::alloc::alloc(layout) };
-    if ptr.is_null() { 0 } else { ptr as i32 }
+    if ptr.is_null() {
+        0
+    } else {
+        ptr as i32
+    }
 }
 
 #[no_mangle]
@@ -249,23 +257,20 @@ pub extern "C" fn invoke(envelope_ptr: i32, envelope_len: i32) -> i32 {
         return write_result(&build_failure("invalid envelope pointer or length"));
     }
 
-    let envelope = unsafe {
-        slice::from_raw_parts(envelope_ptr as *const u8, envelope_len as usize)
-    };
+    let envelope =
+        unsafe { slice::from_raw_parts(envelope_ptr as *const u8, envelope_len as usize) };
 
     let result_cbor = match extract_input_from_envelope(envelope) {
-        Some(input_cbor) => {
-            match extract_text_field(&input_cbor) {
-                Some(text) => {
-                    if is_negative(&text) {
-                        build_low_confidence("negative", 0.30)
-                    } else {
-                        build_success("positive", 0.95)
-                    }
+        Some(input_cbor) => match extract_text_field(&input_cbor) {
+            Some(text) => {
+                if is_negative(&text) {
+                    build_low_confidence("negative", 0.30)
+                } else {
+                    build_success("positive", 0.95)
                 }
-                None => build_failure("input.text field not found"),
             }
-        }
+            None => build_failure("input.text field not found"),
+        },
         None => build_failure("failed to extract input from envelope"),
     };
 

--- a/bricks/classifier-stub/src/lib.rs
+++ b/bricks/classifier-stub/src/lib.rs
@@ -140,6 +140,11 @@ fn contains_ci(haystack: &[u8], needle: &[u8]) -> bool {
     false
 }
 
+// Rationale: ASCII range check via `>=`/`<=` compiles to simpler wasm
+// than `RangeInclusive::contains` (no range allocation) and is more
+// idiomatic for byte-level ops in no_std. Source unchanged keeps the
+// wasm artifact + manifest digest valid.
+#[allow(clippy::manual_range_contains)]
 fn to_lower(b: u8) -> u8 {
     if b >= b'A' && b <= b'Z' {
         b + 32

--- a/bricks/echo/src/lib.rs
+++ b/bricks/echo/src/lib.rs
@@ -203,9 +203,8 @@ pub extern "C" fn invoke(envelope_ptr: i32, envelope_len: i32) -> i32 {
         return write_result(&build_failure_result("invalid envelope pointer or length"));
     }
 
-    let envelope = unsafe {
-        slice::from_raw_parts(envelope_ptr as *const u8, envelope_len as usize)
-    };
+    let envelope =
+        unsafe { slice::from_raw_parts(envelope_ptr as *const u8, envelope_len as usize) };
 
     let result_cbor = match extract_input_from_envelope(envelope) {
         Some(input_cbor) => build_success_result(&input_cbor),

--- a/bricks/echo/src/lib.rs
+++ b/bricks/echo/src/lib.rs
@@ -92,6 +92,11 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 
 /// Minimal envelope parser: extract the raw CBOR bytes of the "input" field.
 /// Only accepts definite-length maps (canonical CBOR per §5.2 requires definite-length).
+// Rationale: clippy suggests `?` but the explicit `match` keeps the
+// "reject indefinite-length map" comment on the rejection arm where it
+// belongs (per spec §5.2). The `?` rewrite buries that intent. Source
+// unchanged keeps the wasm artifact + manifest digest valid.
+#[allow(clippy::question_mark)]
 fn extract_input_from_envelope(envelope: &[u8]) -> Option<Vec<u8>> {
     let mut decoder = minicbor::Decoder::new(envelope);
 

--- a/runtime/src/bin/ncp-bench.rs
+++ b/runtime/src/bin/ncp-bench.rs
@@ -149,7 +149,10 @@ fn main() -> Result<()> {
         eprintln!("Cold start: {} us ({:.3} ms)", us, us as f64 / 1000.0);
         (ctx, Some(us))
     } else {
-        (RuntimeContext::load(&args.graph, &args.brick_dir, args.brick_map.as_deref())?, None)
+        (
+            RuntimeContext::load(&args.graph, &args.brick_dir, args.brick_map.as_deref())?,
+            None,
+        )
     };
 
     let ctx = Arc::new(ctx);
@@ -189,7 +192,11 @@ fn main() -> Result<()> {
         let raw = std::fs::read_to_string(path)
             .with_context(|| format!("reading dataset '{}'", path.display()))?;
         let sha256 = hex::encode(Sha256::digest(raw.as_bytes()));
-        let lines: Vec<String> = raw.lines().filter(|l| !l.trim().is_empty()).map(String::from).collect();
+        let lines: Vec<String> = raw
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(String::from)
+            .collect();
         if lines.is_empty() {
             bail!("dataset '{}' contains no lines", path.display());
         }
@@ -199,7 +206,9 @@ fn main() -> Result<()> {
         }
         eprintln!(
             "  dataset: {} ({} lines, sha256:{})",
-            path.display(), lines.len(), &sha256[..16]
+            path.display(),
+            lines.len(),
+            &sha256[..16]
         );
         InputSource::Dataset {
             lines,
@@ -244,87 +253,94 @@ fn main() -> Result<()> {
     let base_per_thread = total_runs / num_threads;
     let remainder = total_runs % num_threads;
 
-    eprintln!("Bench: {} iterations across {} thread(s)...", total_runs, num_threads);
+    eprintln!(
+        "Bench: {} iterations across {} thread(s)...",
+        total_runs, num_threads
+    );
 
     let wall_start = Instant::now();
 
-    let handles: Vec<_> = (0..num_threads).map(|t| {
-        let ctx = Arc::clone(&ctx);
-        let source = Arc::clone(&source);
-        let pattern = Arc::clone(&pattern);
-        let runs = base_per_thread + if t < remainder { 1 } else { 0 };
-        // Offset so each thread works on different dataset indices
-        let index_offset = t * base_per_thread + t.min(remainder);
+    let handles: Vec<_> = (0..num_threads)
+        .map(|t| {
+            let ctx = Arc::clone(&ctx);
+            let source = Arc::clone(&source);
+            let pattern = Arc::clone(&pattern);
+            let runs = base_per_thread + if t < remainder { 1 } else { 0 };
+            // Offset so each thread works on different dataset indices
+            let index_offset = t * base_per_thread + t.min(remainder);
 
-        std::thread::spawn(move || -> Result<ThreadResults> {
-            let mut tracer = NullTrace;
-            let opts = ExecuteOptions {
-                trace_id: Some("bench-trace".to_string()),
-                session_id: Some("bench-session".to_string()),
-                verbose: false,
-                all_terminals: false,
-                ..Default::default()
-            };
+            std::thread::spawn(move || -> Result<ThreadResults> {
+                let mut tracer = NullTrace;
+                let opts = ExecuteOptions {
+                    trace_id: Some("bench-trace".to_string()),
+                    session_id: Some("bench-session".to_string()),
+                    verbose: false,
+                    all_terminals: false,
+                    ..Default::default()
+                };
 
-            let mut execute_us: Vec<u64> = Vec::with_capacity(runs);
-            let mut end_to_end_us: Vec<u64> = Vec::with_capacity(runs);
-            let mut total_llm_invokes: u64 = 0;
-            let mut runs_with_llm: u64 = 0;
-            let mut total_steps: u64 = 0;
+                let mut execute_us: Vec<u64> = Vec::with_capacity(runs);
+                let mut end_to_end_us: Vec<u64> = Vec::with_capacity(runs);
+                let mut total_llm_invokes: u64 = 0;
+                let mut runs_with_llm: u64 = 0;
+                let mut total_steps: u64 = 0;
 
-            for i in 0..runs {
-                let mut run_llm_invokes: u64 = 0;
+                for i in 0..runs {
+                    let mut run_llm_invokes: u64 = 0;
 
-                let mut on_invoke = |metric: InvokeMetric| {
-                    if !simulating { return; }
-                    if metric.brick_id.contains(&*pattern) {
-                        run_llm_invokes += 1;
-                        std::thread::sleep(std::time::Duration::from_millis(
-                            simulate_llm_ms.unwrap(),
-                        ));
+                    let mut on_invoke = |metric: InvokeMetric| {
+                        if !simulating {
+                            return;
+                        }
+                        if metric.brick_id.contains(&*pattern) {
+                            run_llm_invokes += 1;
+                            std::thread::sleep(std::time::Duration::from_millis(
+                                simulate_llm_ms.unwrap(),
+                            ));
+                        }
+                    };
+
+                    let mut hooks = ExecuteHooks {
+                        on_invoke: Some(&mut on_invoke),
+                    };
+
+                    let e2e_start = Instant::now();
+                    let json_input = match source.as_ref() {
+                        InputSource::Single(v) => std::borrow::Cow::Borrowed(v),
+                        InputSource::Dataset { lines, .. } => {
+                            let di = (index_offset + i) % lines.len();
+                            let v = parse_dataset_line(&lines[di], di)?;
+                            std::borrow::Cow::Owned(v)
+                        }
+                    };
+                    let exec_start = Instant::now();
+                    let report = ctx.execute(&json_input, &mut tracer, &mut hooks, &opts)?;
+                    let exec_elapsed = exec_start.elapsed();
+                    let e2e_elapsed = e2e_start.elapsed();
+
+                    execute_us.push(exec_elapsed.as_micros() as u64);
+                    end_to_end_us.push(e2e_elapsed.as_micros() as u64);
+                    total_steps += report.total_steps;
+                    total_llm_invokes += run_llm_invokes;
+                    if run_llm_invokes > 0 {
+                        runs_with_llm += 1;
                     }
-                };
 
-                let mut hooks = ExecuteHooks {
-                    on_invoke: Some(&mut on_invoke),
-                };
-
-                let e2e_start = Instant::now();
-                let json_input = match source.as_ref() {
-                    InputSource::Single(v) => std::borrow::Cow::Borrowed(v),
-                    InputSource::Dataset { lines, .. } => {
-                        let di = (index_offset + i) % lines.len();
-                        let v = parse_dataset_line(&lines[di], di)?;
-                        std::borrow::Cow::Owned(v)
+                    if report.terminals.is_empty() {
+                        bail!("bench run produced no terminal results");
                     }
-                };
-                let exec_start = Instant::now();
-                let report = ctx.execute(&json_input, &mut tracer, &mut hooks, &opts)?;
-                let exec_elapsed = exec_start.elapsed();
-                let e2e_elapsed = e2e_start.elapsed();
-
-                execute_us.push(exec_elapsed.as_micros() as u64);
-                end_to_end_us.push(e2e_elapsed.as_micros() as u64);
-                total_steps += report.total_steps;
-                total_llm_invokes += run_llm_invokes;
-                if run_llm_invokes > 0 {
-                    runs_with_llm += 1;
                 }
 
-                if report.terminals.is_empty() {
-                    bail!("bench run produced no terminal results");
-                }
-            }
-
-            Ok(ThreadResults {
-                execute_us,
-                end_to_end_us,
-                total_llm_invokes,
-                runs_with_llm,
-                total_steps,
+                Ok(ThreadResults {
+                    execute_us,
+                    end_to_end_us,
+                    total_llm_invokes,
+                    runs_with_llm,
+                    total_steps,
+                })
             })
         })
-    }).collect();
+        .collect();
 
     // Collect results from all threads
     let mut all_execute_us: Vec<u64> = Vec::with_capacity(total_runs);
@@ -334,7 +350,9 @@ fn main() -> Result<()> {
     let mut total_steps: u64 = 0;
 
     for handle in handles {
-        let tr = handle.join().map_err(|_| anyhow::anyhow!("worker thread panicked"))??;
+        let tr = handle
+            .join()
+            .map_err(|_| anyhow::anyhow!("worker thread panicked"))??;
         all_execute_us.extend(tr.execute_us);
         all_e2e_us.extend(tr.end_to_end_us);
         total_llm_invokes += tr.total_llm_invokes;
@@ -428,9 +446,15 @@ fn main() -> Result<()> {
             0.0
         };
         obj.insert("simulate_llm_ms".into(), serde_json::json!(simulate_llm_ms));
-        obj.insert("llm_brick_pattern".into(), serde_json::json!(pattern.as_ref()));
+        obj.insert(
+            "llm_brick_pattern".into(),
+            serde_json::json!(pattern.as_ref()),
+        );
         obj.insert("llm_invokes".into(), serde_json::json!(total_llm_invokes));
-        obj.insert("llm_invokes_per_run".into(), serde_json::json!(total_llm_invokes as f64 / count as f64));
+        obj.insert(
+            "llm_invokes_per_run".into(),
+            serde_json::json!(total_llm_invokes as f64 / count as f64),
+        );
         obj.insert("runs_with_llm".into(), serde_json::json!(runs_with_llm));
         obj.insert("p_llm_requests".into(), serde_json::json!(p_llm_requests));
         obj.insert("k_llm".into(), serde_json::json!(k_llm));
@@ -442,7 +466,12 @@ fn main() -> Result<()> {
     }
 
     // Dataset-specific fields
-    if let InputSource::Dataset { lines, path, sha256 } = source.as_ref() {
+    if let InputSource::Dataset {
+        lines,
+        path,
+        sha256,
+    } = source.as_ref()
+    {
         obj.insert("mode".into(), serde_json::json!("dataset"));
         obj.insert("dataset_path".into(), serde_json::json!(path));
         obj.insert("dataset_size".into(), serde_json::json!(lines.len()));
@@ -498,10 +527,40 @@ fn percentile(sorted: &[u64], pct: f64) -> u64 {
 }
 
 fn print_stats(prefix: &str, s: &Stats) {
-    eprintln!("{}  mean: {:>8} us  ({:.3} ms)", prefix, s.mean, s.mean as f64 / 1000.0);
-    eprintln!("{}  min:  {:>8} us  ({:.3} ms)", prefix, s.min, s.min as f64 / 1000.0);
-    eprintln!("{}  max:  {:>8} us  ({:.3} ms)", prefix, s.max, s.max as f64 / 1000.0);
-    eprintln!("{}  p50:  {:>8} us  ({:.3} ms)", prefix, s.p50, s.p50 as f64 / 1000.0);
-    eprintln!("{}  p95:  {:>8} us  ({:.3} ms)", prefix, s.p95, s.p95 as f64 / 1000.0);
-    eprintln!("{}  p99:  {:>8} us  ({:.3} ms)", prefix, s.p99, s.p99 as f64 / 1000.0);
+    eprintln!(
+        "{}  mean: {:>8} us  ({:.3} ms)",
+        prefix,
+        s.mean,
+        s.mean as f64 / 1000.0
+    );
+    eprintln!(
+        "{}  min:  {:>8} us  ({:.3} ms)",
+        prefix,
+        s.min,
+        s.min as f64 / 1000.0
+    );
+    eprintln!(
+        "{}  max:  {:>8} us  ({:.3} ms)",
+        prefix,
+        s.max,
+        s.max as f64 / 1000.0
+    );
+    eprintln!(
+        "{}  p50:  {:>8} us  ({:.3} ms)",
+        prefix,
+        s.p50,
+        s.p50 as f64 / 1000.0
+    );
+    eprintln!(
+        "{}  p95:  {:>8} us  ({:.3} ms)",
+        prefix,
+        s.p95,
+        s.p95 as f64 / 1000.0
+    );
+    eprintln!(
+        "{}  p99:  {:>8} us  ({:.3} ms)",
+        prefix,
+        s.p99,
+        s.p99 as f64 / 1000.0
+    );
 }

--- a/runtime/src/engine.rs
+++ b/runtime/src/engine.rs
@@ -35,9 +35,7 @@ impl CompiledBrick {
         if mem_bytes == 0 {
             bail!("limits.max_mem_mb must be > 0");
         }
-        let limits = StoreLimitsBuilder::new()
-            .memory_size(mem_bytes)
-            .build();
+        let limits = StoreLimitsBuilder::new().memory_size(mem_bytes).build();
         let mut store = Store::new(&self.engine, StoreState { limits });
         store.limiter(|state| &mut state.limits);
 

--- a/runtime/src/envelope.rs
+++ b/runtime/src/envelope.rs
@@ -26,6 +26,10 @@ pub const ROOT_TRIGGER: Trigger<'static> = Trigger {
 /// Input auto-detection:
 ///   - If JSON has top-level "input" key → use its value
 ///   - Else → wrap entire JSON as input
+// Rationale: envelope construction needs these distinct fields (graph
+// context + trace metadata + step + trigger). Refactor into a builder
+// struct in Phase 3B/3C if/when the signature grows further.
+#[allow(clippy::too_many_arguments)]
 pub fn build_envelope(
     json_input: &serde_json::Value,
     graph_id: &str,

--- a/runtime/src/envelope.rs
+++ b/runtime/src/envelope.rs
@@ -50,7 +50,8 @@ pub fn build_envelope(
     enc.map(4).context("encoding envelope map")?;
 
     // 1. carry_state = null
-    enc.str("carry_state").context("encoding 'carry_state' key")?;
+    enc.str("carry_state")
+        .context("encoding 'carry_state' key")?;
     enc.null().context("encoding carry_state null")?;
 
     // 2. ctx (7 keys, sorted: graph_id, graph_version, node_id, session_id, step, trace_id, trigger)
@@ -58,12 +59,16 @@ pub fn build_envelope(
     enc.map(7).context("encoding ctx map")?;
     enc.str("graph_id").context("encoding ctx.graph_id key")?;
     enc.str(graph_id).context("encoding ctx.graph_id value")?;
-    enc.str("graph_version").context("encoding ctx.graph_version key")?;
-    enc.str(graph_version).context("encoding ctx.graph_version value")?;
+    enc.str("graph_version")
+        .context("encoding ctx.graph_version key")?;
+    enc.str(graph_version)
+        .context("encoding ctx.graph_version value")?;
     enc.str("node_id").context("encoding ctx.node_id key")?;
     enc.str(node_id).context("encoding ctx.node_id value")?;
-    enc.str("session_id").context("encoding ctx.session_id key")?;
-    enc.str(session_id).context("encoding ctx.session_id value")?;
+    enc.str("session_id")
+        .context("encoding ctx.session_id key")?;
+    enc.str(session_id)
+        .context("encoding ctx.session_id value")?;
     enc.str("step").context("encoding ctx.step key")?;
     enc.u64(step).context("encoding ctx.step value")?;
     enc.str("trace_id").context("encoding ctx.trace_id key")?;
@@ -72,11 +77,16 @@ pub fn build_envelope(
     // trigger map (3 keys, sorted: edge_id, source_node_id, source_step)
     enc.map(3).context("encoding trigger map")?;
     enc.str("edge_id").context("encoding trigger.edge_id key")?;
-    enc.str(trigger.edge_id).context("encoding trigger.edge_id value")?;
-    enc.str("source_node_id").context("encoding trigger.source_node_id key")?;
-    enc.str(trigger.source_node_id).context("encoding trigger.source_node_id value")?;
-    enc.str("source_step").context("encoding trigger.source_step key")?;
-    enc.u64(trigger.source_step).context("encoding trigger.source_step value")?;
+    enc.str(trigger.edge_id)
+        .context("encoding trigger.edge_id value")?;
+    enc.str("source_node_id")
+        .context("encoding trigger.source_node_id key")?;
+    enc.str(trigger.source_node_id)
+        .context("encoding trigger.source_node_id value")?;
+    enc.str("source_step")
+        .context("encoding trigger.source_step key")?;
+    enc.u64(trigger.source_step)
+        .context("encoding trigger.source_step value")?;
 
     // 3. graph_refs = {}
     enc.str("graph_refs").context("encoding 'graph_refs' key")?;
@@ -91,10 +101,17 @@ pub fn build_envelope(
 
 /// Recursively encode a serde_json::Value as CBOR.
 /// Object keys are sorted alphabetically for cross-runtime determinism.
-fn encode_json_value<W: Write>(enc: &mut Encoder<W>, val: &serde_json::Value) -> Result<(), encode::Error<W::Error>> {
+fn encode_json_value<W: Write>(
+    enc: &mut Encoder<W>,
+    val: &serde_json::Value,
+) -> Result<(), encode::Error<W::Error>> {
     match val {
-        serde_json::Value::Null => { enc.null()?; }
-        serde_json::Value::Bool(b) => { enc.bool(*b)?; }
+        serde_json::Value::Null => {
+            enc.null()?;
+        }
+        serde_json::Value::Bool(b) => {
+            enc.bool(*b)?;
+        }
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
                 enc.i64(i)?;
@@ -106,7 +123,9 @@ fn encode_json_value<W: Write>(enc: &mut Encoder<W>, val: &serde_json::Value) ->
                 return Err(encode::Error::message("unsupported JSON number"));
             }
         }
-        serde_json::Value::String(s) => { enc.str(s)?; }
+        serde_json::Value::String(s) => {
+            enc.str(s)?;
+        }
         serde_json::Value::Array(arr) => {
             enc.array(arr.len() as u64)?;
             for item in arr {
@@ -132,27 +151,35 @@ mod tests {
 
     #[test]
     fn envelope_deterministic_regardless_of_key_order() {
-        let json_a: serde_json::Value = serde_json::from_str(
-            r#"{"alpha": 1, "beta": "two", "gamma": [3, 4]}"#
-        ).unwrap();
-        let json_b: serde_json::Value = serde_json::from_str(
-            r#"{"gamma": [3, 4], "alpha": 1, "beta": "two"}"#
-        ).unwrap();
+        let json_a: serde_json::Value =
+            serde_json::from_str(r#"{"alpha": 1, "beta": "two", "gamma": [3, 4]}"#).unwrap();
+        let json_b: serde_json::Value =
+            serde_json::from_str(r#"{"gamma": [3, 4], "alpha": 1, "beta": "two"}"#).unwrap();
 
-        let env_a = build_envelope(&json_a, "g1", "v1", "n1", "t1", "s1", 0, &ROOT_TRIGGER).unwrap();
-        let env_b = build_envelope(&json_b, "g1", "v1", "n1", "t1", "s1", 0, &ROOT_TRIGGER).unwrap();
+        let env_a =
+            build_envelope(&json_a, "g1", "v1", "n1", "t1", "s1", 0, &ROOT_TRIGGER).unwrap();
+        let env_b =
+            build_envelope(&json_b, "g1", "v1", "n1", "t1", "s1", 0, &ROOT_TRIGGER).unwrap();
 
-        assert_eq!(env_a, env_b, "envelopes must be byte-identical regardless of JSON key order");
+        assert_eq!(
+            env_a, env_b,
+            "envelopes must be byte-identical regardless of JSON key order"
+        );
     }
 
     #[test]
     fn envelope_auto_wraps_raw_input() {
         let raw: serde_json::Value = serde_json::from_str(r#"{"text": "hello"}"#).unwrap();
-        let wrapped: serde_json::Value = serde_json::from_str(r#"{"input": {"text": "hello"}}"#).unwrap();
+        let wrapped: serde_json::Value =
+            serde_json::from_str(r#"{"input": {"text": "hello"}}"#).unwrap();
 
         let env_raw = build_envelope(&raw, "g1", "v1", "n1", "t1", "s1", 0, &ROOT_TRIGGER).unwrap();
-        let env_wrapped = build_envelope(&wrapped, "g1", "v1", "n1", "t1", "s1", 0, &ROOT_TRIGGER).unwrap();
+        let env_wrapped =
+            build_envelope(&wrapped, "g1", "v1", "n1", "t1", "s1", 0, &ROOT_TRIGGER).unwrap();
 
-        assert_eq!(env_raw, env_wrapped, "raw and wrapped inputs must produce identical envelopes");
+        assert_eq!(
+            env_raw, env_wrapped,
+            "raw and wrapped inputs must produce identical envelopes"
+        );
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -124,15 +124,9 @@ struct Task {
 
 impl RuntimeContext {
     /// Load from file paths (CLI convenience).
-    pub fn load(
-        graph_path: &Path,
-        brick_dir: &Path,
-        brick_map: Option<&Path>,
-    ) -> Result<Self> {
+    pub fn load(graph_path: &Path, brick_dir: &Path, brick_map: Option<&Path>) -> Result<Self> {
         let graph = manifest::load_graph(graph_path)?;
-        let brick_map = brick_map
-            .map(|p| resolver::load_brick_map(p))
-            .transpose()?;
+        let brick_map = brick_map.map(|p| resolver::load_brick_map(p)).transpose()?;
         Self::from_graph(graph, brick_dir, &brick_map)
     }
 
@@ -147,7 +141,8 @@ impl RuntimeContext {
         }
 
         let mut compiled_bricks: HashMap<(String, String), engine::CompiledBrick> = HashMap::new();
-        let mut brick_manifests: HashMap<(String, String), manifest::BrickManifest> = HashMap::new();
+        let mut brick_manifests: HashMap<(String, String), manifest::BrickManifest> =
+            HashMap::new();
         let mut node_brick_key: HashMap<String, (String, String)> = HashMap::new();
         let mut resolved_info: Vec<ResolvedBrickInfo> = Vec::new();
 
@@ -158,13 +153,24 @@ impl RuntimeContext {
                 brick_dir,
                 brick_map,
             )?;
-            let key = (node.brick.brick_id.clone(), resolved.manifest.version.clone());
+            let key = (
+                node.brick.brick_id.clone(),
+                resolved.manifest.version.clone(),
+            );
 
-            if node_brick_key.insert(node.node_id.clone(), key.clone()).is_some() {
-                bail!("graph validation failed: duplicate node_id '{}'", node.node_id);
+            if node_brick_key
+                .insert(node.node_id.clone(), key.clone())
+                .is_some()
+            {
+                bail!(
+                    "graph validation failed: duplicate node_id '{}'",
+                    node.node_id
+                );
             }
 
-            if let std::collections::hash_map::Entry::Vacant(entry) = compiled_bricks.entry(key.clone()) {
+            if let std::collections::hash_map::Entry::Vacant(entry) =
+                compiled_bricks.entry(key.clone())
+            {
                 resolved_info.push(ResolvedBrickInfo {
                     brick_id: key.0.clone(),
                     version: key.1.clone(),
@@ -178,11 +184,8 @@ impl RuntimeContext {
         }
 
         // Detect entry node: not the target of any edge
-        let target_nodes: std::collections::HashSet<&str> = graph
-            .edges
-            .iter()
-            .map(|e| e.target_node.as_str())
-            .collect();
+        let target_nodes: std::collections::HashSet<&str> =
+            graph.edges.iter().map(|e| e.target_node.as_str()).collect();
 
         let entry_nodes: Vec<&str> = graph
             .nodes
@@ -228,12 +231,24 @@ impl RuntimeContext {
         }
     }
 
-    pub fn graph_id(&self) -> &str { &self.graph.graph_id }
-    pub fn graph_version(&self) -> &str { &self.graph.graph_version }
-    pub fn node_count(&self) -> usize { self.graph.nodes.len() }
-    pub fn edge_count(&self) -> usize { self.graph.edges.len() }
-    pub fn entry_node_id(&self) -> &str { &self.entry_node_id }
-    pub fn resolved_bricks(&self) -> &[ResolvedBrickInfo] { &self.resolved_info }
+    pub fn graph_id(&self) -> &str {
+        &self.graph.graph_id
+    }
+    pub fn graph_version(&self) -> &str {
+        &self.graph.graph_version
+    }
+    pub fn node_count(&self) -> usize {
+        self.graph.nodes.len()
+    }
+    pub fn edge_count(&self) -> usize {
+        self.graph.edges.len()
+    }
+    pub fn entry_node_id(&self) -> &str {
+        &self.entry_node_id
+    }
+    pub fn resolved_bricks(&self) -> &[ResolvedBrickInfo] {
+        &self.resolved_info
+    }
 
     /// Execute the graph with the given input.
     pub fn execute(
@@ -243,17 +258,25 @@ impl RuntimeContext {
         hooks: &mut ExecuteHooks<'_>,
         opts: &ExecuteOptions,
     ) -> Result<ExecutionReport> {
-        let trace_id = opts.trace_id.as_deref()
+        let trace_id = opts
+            .trace_id
+            .as_deref()
             .map(str::to_owned)
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-        let session_id = opts.session_id.as_deref()
+        let session_id = opts
+            .session_id
+            .as_deref()
             .map(str::to_owned)
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
         let mut queue: std::collections::VecDeque<Task> = std::collections::VecDeque::new();
         let mut step: u64 = 0;
         let mut terminals: Vec<TerminalResult> = Vec::new();
-        let mut counts = ResultCounts { success: 0, low_confidence: 0, failure: 0 };
+        let mut counts = ResultCounts {
+            success: 0,
+            low_confidence: 0,
+            failure: 0,
+        };
         let verbose = opts.verbose;
         let tracing = tracer.enabled();
 
@@ -272,11 +295,14 @@ impl RuntimeContext {
             if let Some(max) = opts.max_steps {
                 if step >= max {
                     let msg = format!("max_steps budget ({max}) exhausted");
-                    if verbose { eprintln!("Safety budget: {msg}"); }
+                    if verbose {
+                        eprintln!("Safety budget: {msg}");
+                    }
                     counts.failure += 1;
                     terminals.push(TerminalResult {
                         node_id: task.node_id.clone(),
-                        brick_id: self.node_brick_key
+                        brick_id: self
+                            .node_brick_key
                             .get(&task.node_id)
                             .map(|k| k.0.clone())
                             .unwrap_or_else(|| "__runtime__".to_string()),
@@ -287,13 +313,16 @@ impl RuntimeContext {
                 }
             }
 
-            let brick_key = self.node_brick_key
+            let brick_key = self
+                .node_brick_key
                 .get(&task.node_id)
                 .with_context(|| format!("no brick key recorded for node '{}'", task.node_id))?;
-            let compiled = self.compiled_bricks
+            let compiled = self
+                .compiled_bricks
                 .get(brick_key)
                 .with_context(|| format!("no compiled brick for key {:?}", brick_key))?;
-            let brick_manifest = self.brick_manifests
+            let brick_manifest = self
+                .brick_manifests
                 .get(brick_key)
                 .with_context(|| format!("no manifest for key {:?}", brick_key))?;
 
@@ -318,11 +347,14 @@ impl RuntimeContext {
             let mut pre_invoke_failure: Option<result::BrickResult> = None;
             if let Some(max_input) = brick_manifest.limits.max_input_bytes {
                 if env.len() as u64 > max_input {
-                    let msg = format!(
+                    let msg =
+                        format!(
                         "envelope too large for brick '{}': {} bytes > limits.max_input_bytes {}",
                         brick_key.0, env.len(), max_input,
                     );
-                    if verbose { eprintln!("  {msg}"); }
+                    if verbose {
+                        eprintln!("  {msg}");
+                    }
                     pre_invoke_failure = Some(result::trap_failure("INVALID_INPUT", msg));
                 }
             }
@@ -336,13 +368,17 @@ impl RuntimeContext {
                 } else {
                     eprintln!(
                         "[step {}] Invoking brick '{}' node '{}' ({} byte envelope)",
-                        step, brick_key.0, task.node_id, env.len(),
+                        step,
+                        brick_key.0,
+                        task.node_id,
+                        env.len(),
                     );
                 }
             }
 
             // Invoke brick (or use pre-invoke failure)
-            let (brick_result, raw_result_bytes, latency_ms) = if let Some(br) = pre_invoke_failure {
+            let (brick_result, raw_result_bytes, latency_ms) = if let Some(br) = pre_invoke_failure
+            {
                 (br, None, 0.0)
             } else {
                 let start = std::time::Instant::now();
@@ -355,12 +391,16 @@ impl RuntimeContext {
 
                 match invoke_result {
                     Ok(result_bytes) => {
-                        if verbose { eprintln!("  Got {} byte result", result_bytes.len()); }
+                        if verbose {
+                            eprintln!("  Got {} byte result", result_bytes.len());
+                        }
                         let decoded = match result::decode_result(&result_bytes) {
                             Ok(r) => r,
                             Err(e) => {
                                 let msg = format!("{e:#}");
-                                if verbose { eprintln!("  Result rejected: {msg}"); }
+                                if verbose {
+                                    eprintln!("  Result rejected: {msg}");
+                                }
                                 result::trap_failure("RUNTIME_REJECTED", msg)
                             }
                         };
@@ -380,7 +420,9 @@ impl RuntimeContext {
                         } else {
                             "COMPUTATION_ERROR"
                         };
-                        if verbose { eprintln!("  Brick trap: {msg}"); }
+                        if verbose {
+                            eprintln!("  Brick trap: {msg}");
+                        }
                         (result::trap_failure(error_class, msg), None, latency)
                     }
                 }
@@ -430,10 +472,13 @@ impl RuntimeContext {
                 });
             }
 
-            if verbose { eprintln!("  Result type: {}", brick_result.result_type()); }
+            if verbose {
+                eprintln!("  Result type: {}", brick_result.result_type());
+            }
 
             // ── Routing ────────────────────────────────────────────
-            let outbound_indices = self.edges_by_source
+            let outbound_indices = self
+                .edges_by_source
                 .get(task.node_id.as_str())
                 .cloned()
                 .unwrap_or_default();
@@ -442,14 +487,14 @@ impl RuntimeContext {
                 .map(|&i| &self.graph.edges[i])
                 .collect();
 
-            let output_confidence = brick_result
-                .output()
-                .and_then(mapping::extract_confidence);
+            let output_confidence = brick_result.output().and_then(mapping::extract_confidence);
 
             let routed = router::route(&outbound, &brick_result, output_confidence);
 
             if routed.is_empty() {
-                if verbose { eprintln!("  Terminal node (no outbound edges dispatched)"); }
+                if verbose {
+                    eprintln!("  Terminal node (no outbound edges dispatched)");
+                }
                 terminals.push(TerminalResult {
                     node_id: task.node_id.clone(),
                     brick_id: brick_key.0.clone(),
@@ -458,13 +503,19 @@ impl RuntimeContext {
                 });
             } else {
                 for routed_edge in &routed {
-                    let edge_idx = self.edge_by_id.get(routed_edge.edge_id.as_str())
-                        .with_context(|| format!("routed edge '{}' not found in graph", routed_edge.edge_id))?;
+                    let edge_idx = self
+                        .edge_by_id
+                        .get(routed_edge.edge_id.as_str())
+                        .with_context(|| {
+                            format!("routed edge '{}' not found in graph", routed_edge.edge_id)
+                        })?;
                     let edge_def = &self.graph.edges[*edge_idx];
 
                     let mapped_input = if edge_def.mapping.is_empty() {
                         match brick_result.output() {
-                            Some(output) => serde_json::json!({ "input": mapping::cbor_to_json(output) }),
+                            Some(output) => {
+                                serde_json::json!({ "input": mapping::cbor_to_json(output) })
+                            }
                             None => serde_json::json!({ "input": null }),
                         }
                     } else {
@@ -479,10 +530,12 @@ impl RuntimeContext {
                         let mut target_cbor = CborValue::Map(vec![]);
                         for fm in &edge_def.mapping {
                             let resolved = mapping::resolve_path(&source_root, &fm.from)
-                                .with_context(|| format!(
-                                    "mapping '{}' → '{}': source path '{}' not found in output",
-                                    fm.from, fm.to, fm.from,
-                                ))?;
+                                .with_context(|| {
+                                    format!(
+                                        "mapping '{}' → '{}': source path '{}' not found in output",
+                                        fm.from, fm.to, fm.from,
+                                    )
+                                })?;
                             let overlay = mapping::set_path(&fm.to, resolved);
                             target_cbor = mapping::merge_maps(target_cbor, overlay);
                         }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -35,14 +35,9 @@ pub struct InvokeMetric {
 }
 
 /// Hooks for streaming execution events.
+#[derive(Default)]
 pub struct ExecuteHooks<'a> {
     pub on_invoke: Option<&'a mut dyn FnMut(InvokeMetric)>,
-}
-
-impl<'a> Default for ExecuteHooks<'a> {
-    fn default() -> Self {
-        Self { on_invoke: None }
-    }
 }
 
 /// Options for a single execute() call.
@@ -126,7 +121,7 @@ impl RuntimeContext {
     /// Load from file paths (CLI convenience).
     pub fn load(graph_path: &Path, brick_dir: &Path, brick_map: Option<&Path>) -> Result<Self> {
         let graph = manifest::load_graph(graph_path)?;
-        let brick_map = brick_map.map(|p| resolver::load_brick_map(p)).transpose()?;
+        let brick_map = brick_map.map(resolver::load_brick_map).transpose()?;
         Self::from_graph(graph, brick_dir, &brick_map)
     }
 

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -25,7 +25,17 @@ fn main() -> Result<()> {
             max_steps,
             max_queued,
             verbose,
-        } => run_graph(graph, input, brick_dir, brick_map, trace, all_terminals, max_steps, max_queued, verbose),
+        } => run_graph(
+            graph,
+            input,
+            brick_dir,
+            brick_map,
+            trace,
+            all_terminals,
+            max_steps,
+            max_queued,
+            verbose,
+        ),
     }
 }
 
@@ -41,11 +51,7 @@ fn run_graph(
     verbose: bool,
 ) -> Result<()> {
     // Load and compile graph
-    let ctx = RuntimeContext::load(
-        &graph,
-        &brick_dir,
-        brick_map.as_deref(),
-    )?;
+    let ctx = RuntimeContext::load(&graph, &brick_dir, brick_map.as_deref())?;
 
     eprintln!(
         "Loaded graph '{}' with {} nodes, {} edges",
@@ -95,7 +101,8 @@ fn run_graph(
     }
 
     if all_terminals {
-        let arr: Vec<serde_json::Value> = report.terminals
+        let arr: Vec<serde_json::Value> = report
+            .terminals
             .iter()
             .map(|t| {
                 let mut obj = serde_json::json!({

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -39,6 +39,9 @@ fn main() -> Result<()> {
     }
 }
 
+// Rationale: CLI dispatch shim — args mirror clap-parsed flags 1:1.
+// Refactor into a RunArgs struct in Phase 3B/3C if/when flags grow further.
+#[allow(clippy::too_many_arguments)]
 fn run_graph(
     graph: PathBuf,
     input: PathBuf,

--- a/runtime/src/mapping.rs
+++ b/runtime/src/mapping.rs
@@ -17,9 +17,9 @@ pub fn resolve_path(value: &CborValue, path: &str) -> Option<CborValue> {
     for segment in &segments {
         match current {
             CborValue::Map(pairs) => {
-                let found = pairs.into_iter().find(|(k, _)| {
-                    matches!(k, CborValue::Text(s) if s == segment)
-                });
+                let found = pairs
+                    .into_iter()
+                    .find(|(k, _)| matches!(k, CborValue::Text(s) if s == segment));
                 match found {
                     Some((_, v)) => current = v,
                     None => return None,
@@ -45,10 +45,7 @@ pub fn set_path(path: &str, value: CborValue) -> CborValue {
 
     // Build inside-out: wrap the value in nested single-key maps from right to left
     for segment in segments.into_iter().rev() {
-        result = CborValue::Map(vec![(
-            CborValue::Text(segment.to_string()),
-            result,
-        )]);
+        result = CborValue::Map(vec![(CborValue::Text(segment.to_string()), result)]);
     }
 
     result
@@ -133,16 +130,21 @@ pub fn extract_confidence(value: &CborValue) -> Option<f64> {
 mod tests {
     use super::*;
 
-    fn text(s: &str) -> CborValue { CborValue::Text(s.to_string()) }
-    fn int(n: i64) -> CborValue { CborValue::Integer(n) }
+    fn text(s: &str) -> CborValue {
+        CborValue::Text(s.to_string())
+    }
+    fn int(n: i64) -> CborValue {
+        CborValue::Integer(n)
+    }
 
     fn sample_map() -> CborValue {
         CborValue::Map(vec![
             (text("label"), text("positive")),
             (text("confidence"), CborValue::Float(0.95)),
-            (text("nested"), CborValue::Map(vec![
-                (text("deep"), int(42)),
-            ])),
+            (
+                text("nested"),
+                CborValue::Map(vec![(text("deep"), int(42))]),
+            ),
         ])
     }
 
@@ -200,8 +202,14 @@ mod tests {
         let a = set_path("x", int(1));
         let b = set_path("y", int(2));
         let merged = merge_maps(a, b);
-        assert!(matches!(resolve_path(&merged, "x"), Some(CborValue::Integer(1))));
-        assert!(matches!(resolve_path(&merged, "y"), Some(CborValue::Integer(2))));
+        assert!(matches!(
+            resolve_path(&merged, "x"),
+            Some(CborValue::Integer(1))
+        ));
+        assert!(matches!(
+            resolve_path(&merged, "y"),
+            Some(CborValue::Integer(2))
+        ));
     }
 
     #[test]
@@ -209,8 +217,14 @@ mod tests {
         let a = set_path("input.x", int(1));
         let b = set_path("input.y", int(2));
         let merged = merge_maps(a, b);
-        assert!(matches!(resolve_path(&merged, "input.x"), Some(CborValue::Integer(1))));
-        assert!(matches!(resolve_path(&merged, "input.y"), Some(CborValue::Integer(2))));
+        assert!(matches!(
+            resolve_path(&merged, "input.x"),
+            Some(CborValue::Integer(1))
+        ));
+        assert!(matches!(
+            resolve_path(&merged, "input.y"),
+            Some(CborValue::Integer(2))
+        ));
     }
 
     #[test]
@@ -220,17 +234,24 @@ mod tests {
             (text("b"), int(2)),
             (text("c"), int(3)),
         ]);
-        let overlay = CborValue::Map(vec![
-            (text("b"), int(20)),
-            (text("d"), int(4)),
-        ]);
+        let overlay = CborValue::Map(vec![(text("b"), int(20)), (text("d"), int(4))]);
         let merged = merge_maps(base, overlay);
         if let CborValue::Map(pairs) = &merged {
-            let keys: Vec<&str> = pairs.iter().map(|(k, _)| {
-                if let CborValue::Text(s) = k { s.as_str() } else { "" }
-            }).collect();
+            let keys: Vec<&str> = pairs
+                .iter()
+                .map(|(k, _)| {
+                    if let CborValue::Text(s) = k {
+                        s.as_str()
+                    } else {
+                        ""
+                    }
+                })
+                .collect();
             assert_eq!(keys, vec!["a", "b", "c", "d"]);
-            assert!(matches!(resolve_path(&merged, "b"), Some(CborValue::Integer(20))));
+            assert!(matches!(
+                resolve_path(&merged, "b"),
+                Some(CborValue::Integer(20))
+            ));
         } else {
             panic!("expected map");
         }

--- a/runtime/src/resolver.rs
+++ b/runtime/src/resolver.rs
@@ -69,10 +69,7 @@ fn resolve_brick_dir(
         }
     }
 
-    let short_name = brick_id
-        .rsplit('.')
-        .next()
-        .unwrap_or(brick_id);
+    let short_name = brick_id.rsplit('.').next().unwrap_or(brick_id);
     let dir = brick_dir.join(short_name);
 
     if !dir.is_dir() {
@@ -132,7 +129,12 @@ fn select_wasm(brick_id: &str, dir: &Path, artifact_path: &Option<PathBuf>) -> R
     // 4. Error (sorted candidates for determinism)
     let candidates: Vec<String> = wasm_files
         .iter()
-        .map(|p| p.file_name().unwrap_or_default().to_string_lossy().into_owned())
+        .map(|p| {
+            p.file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned()
+        })
         .collect();
 
     if candidates.is_empty() {
@@ -167,14 +169,12 @@ fn verify_artifact(brick_id: &str, manifest: &BrickManifest, wasm_bytes: &[u8]) 
 
     // Digest check — expect "sha256:<hex>"
     let expected_digest = &manifest.artifact.digest;
-    let expected_hex = expected_digest
-        .strip_prefix("sha256:")
-        .with_context(|| {
-            format!(
-                "unsupported digest format for '{}': expected 'sha256:<hex>', got '{}'",
-                brick_id, expected_digest
-            )
-        })?;
+    let expected_hex = expected_digest.strip_prefix("sha256:").with_context(|| {
+        format!(
+            "unsupported digest format for '{}': expected 'sha256:<hex>', got '{}'",
+            brick_id, expected_digest
+        )
+    })?;
 
     // Strict validation: must be exactly 64 lowercase hex chars
     let expected_hex = expected_hex.to_ascii_lowercase();

--- a/runtime/src/resolver.rs
+++ b/runtime/src/resolver.rs
@@ -110,7 +110,7 @@ fn select_wasm(brick_id: &str, dir: &Path, artifact_path: &Option<PathBuf>) -> R
         .with_context(|| format!("reading directory '{}'", dir.display()))?
         .filter_map(|entry| entry.ok())
         .map(|entry| entry.path())
-        .filter(|p| p.extension().map_or(false, |ext| ext == "wasm"))
+        .filter(|p| p.extension().is_some_and(|ext| ext == "wasm"))
         .collect();
     wasm_files.sort();
 

--- a/runtime/src/result.rs
+++ b/runtime/src/result.rs
@@ -90,17 +90,16 @@ pub fn decode_result(cbor_bytes: &[u8]) -> Result<BrickResult> {
     // Collect all top-level key-value pairs, rejecting duplicates
     let mut fields: HashMap<String, CborValue> = HashMap::new();
     for _ in 0..map_len {
-        let key = decode_text(&mut decoder)
-            .context("result map key must be a text string")?;
-        let value = decode_value(&mut decoder)
-            .context("decoding result map value")?;
+        let key = decode_text(&mut decoder).context("result map key must be a text string")?;
+        let value = decode_value(&mut decoder).context("decoding result map value")?;
         if fields.insert(key.clone(), value).is_some() {
             bail!("duplicate top-level key in result map: '{key}'");
         }
     }
 
     // Extract discriminant
-    let type_val = fields.get("type")
+    let type_val = fields
+        .get("type")
         .ok_or_else(|| anyhow::anyhow!("result missing 'type' discriminant field"))?;
     let type_str = match type_val {
         CborValue::Text(s) => s.as_str(),
@@ -111,13 +110,16 @@ pub fn decode_result(cbor_bytes: &[u8]) -> Result<BrickResult> {
         "Success" => validate_success(&fields),
         "LowConfidence" => validate_low_confidence(&fields),
         "Failure" => validate_failure(&fields),
-        other => bail!("unknown result type '{other}' (expected Success, LowConfidence, or Failure)"),
+        other => {
+            bail!("unknown result type '{other}' (expected Success, LowConfidence, or Failure)")
+        }
     }
 }
 
 fn validate_success(fields: &HashMap<String, CborValue>) -> Result<BrickResult> {
     // MUST have output
-    let output = fields.get("output")
+    let output = fields
+        .get("output")
         .ok_or_else(|| anyhow::anyhow!("Success result missing 'output' field"))?
         .clone();
 
@@ -143,15 +145,16 @@ fn validate_success(fields: &HashMap<String, CborValue>) -> Result<BrickResult> 
 
 fn validate_low_confidence(fields: &HashMap<String, CborValue>) -> Result<BrickResult> {
     // MUST have output
-    let output = fields.get("output")
+    let output = fields
+        .get("output")
         .ok_or_else(|| anyhow::anyhow!("LowConfidence result missing 'output' field"))?
         .clone();
 
     // MUST have error
-    let error_val = fields.get("error")
+    let error_val = fields
+        .get("error")
         .ok_or_else(|| anyhow::anyhow!("LowConfidence result missing 'error' field"))?;
-    let error = parse_error_object(error_val)
-        .context("parsing LowConfidence error object")?;
+    let error = parse_error_object(error_val).context("parsing LowConfidence error object")?;
 
     // error.error_class MUST be LOW_CONFIDENCE
     if error.error_class != "LOW_CONFIDENCE" {
@@ -178,10 +181,10 @@ fn validate_low_confidence(fields: &HashMap<String, CborValue>) -> Result<BrickR
 
 fn validate_failure(fields: &HashMap<String, CborValue>) -> Result<BrickResult> {
     // MUST have error
-    let error_val = fields.get("error")
+    let error_val = fields
+        .get("error")
         .ok_or_else(|| anyhow::anyhow!("Failure result missing 'error' field"))?;
-    let error = parse_error_object(error_val)
-        .context("parsing Failure error object")?;
+    let error = parse_error_object(error_val).context("parsing Failure error object")?;
 
     // error.error_class MUST NOT be LOW_CONFIDENCE
     if error.error_class == "LOW_CONFIDENCE" {
@@ -249,10 +252,9 @@ fn parse_error_object(val: &CborValue) -> Result<ErrorObject> {
         }
     }
 
-    let error_class = error_class
-        .ok_or_else(|| anyhow::anyhow!("error object missing 'error_class' field"))?;
-    let message = message
-        .ok_or_else(|| anyhow::anyhow!("error object missing 'message' field"))?;
+    let error_class =
+        error_class.ok_or_else(|| anyhow::anyhow!("error object missing 'error_class' field"))?;
+    let message = message.ok_or_else(|| anyhow::anyhow!("error object missing 'message' field"))?;
 
     Ok(ErrorObject {
         error_class,
@@ -280,19 +282,24 @@ fn decode_text(d: &mut minicbor::Decoder<'_>) -> Result<String> {
 fn decode_value(d: &mut minicbor::Decoder<'_>) -> Result<CborValue> {
     use minicbor::data::Type;
 
-    match d.datatype()
+    match d
+        .datatype()
         .map_err(|e| anyhow::anyhow!("cannot peek CBOR type: {e}"))?
     {
         Type::Null => {
-            d.null().map_err(|e| anyhow::anyhow!("decoding null: {e}"))?;
+            d.null()
+                .map_err(|e| anyhow::anyhow!("decoding null: {e}"))?;
             Ok(CborValue::Null)
         }
         Type::Undefined => {
-            d.undefined().map_err(|e| anyhow::anyhow!("consuming undefined: {e}"))?;
+            d.undefined()
+                .map_err(|e| anyhow::anyhow!("consuming undefined: {e}"))?;
             bail!("CBOR undefined is not allowed in NCP results");
         }
         Type::Bool => {
-            let b = d.bool().map_err(|e| anyhow::anyhow!("decoding bool: {e}"))?;
+            let b = d
+                .bool()
+                .map_err(|e| anyhow::anyhow!("decoding bool: {e}"))?;
             Ok(CborValue::Bool(b))
         }
         Type::U8 | Type::U16 | Type::U32 | Type::U64 => {
@@ -307,7 +314,9 @@ fn decode_value(d: &mut minicbor::Decoder<'_>) -> Result<CborValue> {
             Ok(CborValue::Integer(n))
         }
         Type::F16 | Type::F32 | Type::F64 => {
-            let f = d.f64().map_err(|e| anyhow::anyhow!("decoding float: {e}"))?;
+            let f = d
+                .f64()
+                .map_err(|e| anyhow::anyhow!("decoding float: {e}"))?;
             Ok(CborValue::Float(f))
         }
         Type::String => {
@@ -315,13 +324,15 @@ fn decode_value(d: &mut minicbor::Decoder<'_>) -> Result<CborValue> {
             Ok(CborValue::Text(s))
         }
         Type::Bytes => {
-            let b = d.bytes()
+            let b = d
+                .bytes()
                 .map_err(|e| anyhow::anyhow!("decoding bytes: {e}"))?
                 .to_vec();
             Ok(CborValue::Bytes(b))
         }
         Type::Array => {
-            let len = d.array()
+            let len = d
+                .array()
                 .map_err(|e| anyhow::anyhow!("decoding array: {e}"))?
                 .ok_or_else(|| anyhow::anyhow!("indefinite-length arrays not supported"))?;
             if len > MAX_COLLECTION_LEN {
@@ -334,7 +345,8 @@ fn decode_value(d: &mut minicbor::Decoder<'_>) -> Result<CborValue> {
             Ok(CborValue::Array(items))
         }
         Type::Map => {
-            let len = d.map()
+            let len = d
+                .map()
                 .map_err(|e| anyhow::anyhow!("decoding map: {e}"))?
                 .ok_or_else(|| anyhow::anyhow!("indefinite-length maps not supported"))?;
             if len > MAX_COLLECTION_LEN {
@@ -349,8 +361,7 @@ fn decode_value(d: &mut minicbor::Decoder<'_>) -> Result<CborValue> {
             Ok(CborValue::Map(pairs))
         }
         Type::Tag => {
-            let tag = d.tag()
-                .map_err(|e| anyhow::anyhow!("decoding tag: {e}"))?;
+            let tag = d.tag().map_err(|e| anyhow::anyhow!("decoding tag: {e}"))?;
             bail!("CBOR tags are not supported in Phase 2 results (tag={tag:?})");
         }
         other => bail!("unsupported CBOR type: {other:?}"),
@@ -399,10 +410,18 @@ mod tests {
 
     fn encode_test_value(enc: &mut Encoder<&mut Vec<u8>>, val: &EncodableValue) {
         match val {
-            EncodableValue::Text(s) => { enc.str(s).unwrap(); }
-            EncodableValue::Int(n) => { enc.i64(*n).unwrap(); }
-            EncodableValue::Float(f) => { enc.f64(*f).unwrap(); }
-            EncodableValue::Null => { enc.null().unwrap(); }
+            EncodableValue::Text(s) => {
+                enc.str(s).unwrap();
+            }
+            EncodableValue::Int(n) => {
+                enc.i64(*n).unwrap();
+            }
+            EncodableValue::Float(f) => {
+                enc.f64(*f).unwrap();
+            }
+            EncodableValue::Null => {
+                enc.null().unwrap();
+            }
             EncodableValue::Map(pairs) => {
                 enc.map(pairs.len() as u64).unwrap();
                 for (k, v) in pairs {
@@ -413,7 +432,9 @@ mod tests {
         }
     }
 
-    fn text(s: &str) -> EncodableValue { EncodableValue::Text(s.to_string()) }
+    fn text(s: &str) -> EncodableValue {
+        EncodableValue::Text(s.to_string())
+    }
     fn output_map() -> EncodableValue {
         EncodableValue::Map(vec![
             ("label".into(), text("positive")),
@@ -431,10 +452,7 @@ mod tests {
 
     #[test]
     fn valid_success() {
-        let bytes = encode_result(&[
-            ("type", text("Success")),
-            ("output", output_map()),
-        ]);
+        let bytes = encode_result(&[("type", text("Success")), ("output", output_map())]);
         let result = decode_result(&bytes).unwrap();
         assert_eq!(result.result_type(), "Success");
         assert!(result.output().is_some());
@@ -503,10 +521,7 @@ mod tests {
 
     #[test]
     fn invalid_low_confidence_without_error() {
-        let bytes = encode_result(&[
-            ("type", text("LowConfidence")),
-            ("output", output_map()),
-        ]);
+        let bytes = encode_result(&[("type", text("LowConfidence")), ("output", output_map())]);
         let err = decode_result(&bytes).unwrap_err();
         assert!(err.to_string().contains("missing 'error'"));
     }
@@ -524,35 +539,27 @@ mod tests {
 
     #[test]
     fn invalid_missing_type() {
-        let bytes = encode_result(&[
-            ("output", output_map()),
-        ]);
+        let bytes = encode_result(&[("output", output_map())]);
         let err = decode_result(&bytes).unwrap_err();
         assert!(err.to_string().contains("missing 'type'"));
     }
 
     #[test]
     fn invalid_unknown_type() {
-        let bytes = encode_result(&[
-            ("type", text("Unknown")),
-            ("output", output_map()),
-        ]);
+        let bytes = encode_result(&[("type", text("Unknown")), ("output", output_map())]);
         let err = decode_result(&bytes).unwrap_err();
         assert!(err.to_string().contains("unknown result type"));
     }
 
     #[test]
     fn invalid_error_missing_message() {
-        let error_no_msg = EncodableValue::Map(vec![
-            ("error_class".into(), text("COMPUTATION_ERROR")),
-        ]);
-        let bytes = encode_result(&[
-            ("type", text("Failure")),
-            ("error", error_no_msg),
-        ]);
+        let error_no_msg =
+            EncodableValue::Map(vec![("error_class".into(), text("COMPUTATION_ERROR"))]);
+        let bytes = encode_result(&[("type", text("Failure")), ("error", error_no_msg)]);
         let err = decode_result(&bytes).unwrap_err();
         assert!(
-            err.chain().any(|c| c.to_string().contains("missing 'message'")),
+            err.chain()
+                .any(|c| c.to_string().contains("missing 'message'")),
             "expected cause not found in error chain: {err:?}"
         );
     }
@@ -572,9 +579,12 @@ mod tests {
         let mut buf = Vec::new();
         let mut enc = Encoder::new(&mut buf);
         enc.map(3).unwrap();
-        enc.str("type").unwrap(); enc.str("Success").unwrap();
-        enc.str("output").unwrap(); enc.str("hello").unwrap();
-        enc.str("type").unwrap(); enc.str("Failure").unwrap();
+        enc.str("type").unwrap();
+        enc.str("Success").unwrap();
+        enc.str("output").unwrap();
+        enc.str("hello").unwrap();
+        enc.str("type").unwrap();
+        enc.str("Failure").unwrap();
         let err = decode_result(&buf).unwrap_err();
         assert!(err.to_string().contains("duplicate top-level key"));
     }
@@ -606,15 +616,20 @@ mod tests {
         let mut buf = Vec::new();
         let mut enc = Encoder::new(&mut buf);
         enc.map(2).unwrap();
-        enc.str("type").unwrap(); enc.str("Failure").unwrap();
+        enc.str("type").unwrap();
+        enc.str("Failure").unwrap();
         enc.str("error").unwrap();
         enc.map(3).unwrap();
-        enc.str("error_class").unwrap(); enc.str("COMPUTATION_ERROR").unwrap();
-        enc.str("error_class").unwrap(); enc.str("LOW_CONFIDENCE").unwrap();
-        enc.str("message").unwrap(); enc.str("oops").unwrap();
+        enc.str("error_class").unwrap();
+        enc.str("COMPUTATION_ERROR").unwrap();
+        enc.str("error_class").unwrap();
+        enc.str("LOW_CONFIDENCE").unwrap();
+        enc.str("message").unwrap();
+        enc.str("oops").unwrap();
         let err = decode_result(&buf).unwrap_err();
         assert!(
-            err.chain().any(|c| c.to_string().contains("duplicate key 'error_class'")),
+            err.chain()
+                .any(|c| c.to_string().contains("duplicate key 'error_class'")),
             "expected cause not found in error chain: {err:?}"
         );
     }

--- a/runtime/src/router.rs
+++ b/runtime/src/router.rs
@@ -47,7 +47,7 @@ fn route_on_error(edges: &[&Edge], error_class: &str) -> Vec<RoutedEdge> {
             // edge.target_node. The map keys are the error_class filter.
             e.on_error
                 .as_ref()
-                .map_or(false, |m| m.contains_key(error_class))
+                .is_some_and(|m| m.contains_key(error_class))
         })
         .copied()
         .collect();

--- a/runtime/src/router.rs
+++ b/runtime/src/router.rs
@@ -97,11 +97,14 @@ fn route_on_success(edges: &[&Edge], output_confidence: Option<f64>) -> Vec<Rout
         let mut wb = b.on_success.as_ref().and_then(|s| s.weight).unwrap_or(0.0);
 
         // Defensive determinism: treat non-finite weights as 0.0
-        if !wa.is_finite() { wa = 0.0; }
-        if !wb.is_finite() { wb = 0.0; }
+        if !wa.is_finite() {
+            wa = 0.0;
+        }
+        if !wb.is_finite() {
+            wb = 0.0;
+        }
 
-        wb.total_cmp(&wa)
-            .then_with(|| a.edge_id.cmp(&b.edge_id))
+        wb.total_cmp(&wa).then_with(|| a.edge_id.cmp(&b.edge_id))
     });
 
     candidates
@@ -170,9 +173,15 @@ mod tests {
     #[test]
     fn v1_on_error_single_match() {
         let mut e1 = edge("e1", "recovery_node");
-        e1.on_error = Some(HashMap::from([("COMPUTATION_ERROR".into(), vec!["recovery_node".into()])]));
+        e1.on_error = Some(HashMap::from([(
+            "COMPUTATION_ERROR".into(),
+            vec!["recovery_node".into()],
+        )]));
         let mut e2 = edge("e2", "fallback_node");
-        e2.on_error = Some(HashMap::from([("INVALID_INPUT".into(), vec!["fallback_node".into()])]));
+        e2.on_error = Some(HashMap::from([(
+            "INVALID_INPUT".into(),
+            vec!["fallback_node".into()],
+        )]));
 
         let result = failure("COMPUTATION_ERROR");
         let edges: Vec<&Edge> = vec![&e1, &e2];
@@ -182,7 +191,10 @@ mod tests {
     #[test]
     fn v2_on_error_no_match_terminal() {
         let mut e1 = edge("e1", "fallback_node");
-        e1.on_error = Some(HashMap::from([("INVALID_INPUT".into(), vec!["fallback_node".into()])]));
+        e1.on_error = Some(HashMap::from([(
+            "INVALID_INPUT".into(),
+            vec!["fallback_node".into()],
+        )]));
 
         let result = failure("COMPUTATION_ERROR");
         let edges: Vec<&Edge> = vec![&e1];
@@ -193,10 +205,16 @@ mod tests {
     fn v3_on_error_priority_ordering() {
         let mut e1 = edge("e1", "node_a");
         e1.priority = Some(5);
-        e1.on_error = Some(HashMap::from([("COMPUTATION_ERROR".into(), vec!["node_a".into()])]));
+        e1.on_error = Some(HashMap::from([(
+            "COMPUTATION_ERROR".into(),
+            vec!["node_a".into()],
+        )]));
         let mut e2 = edge("e2", "node_b");
         e2.priority = Some(10);
-        e2.on_error = Some(HashMap::from([("COMPUTATION_ERROR".into(), vec!["node_b".into()])]));
+        e2.on_error = Some(HashMap::from([(
+            "COMPUTATION_ERROR".into(),
+            vec!["node_b".into()],
+        )]));
 
         let result = failure("COMPUTATION_ERROR");
         let edges: Vec<&Edge> = vec![&e1, &e2];
@@ -207,10 +225,16 @@ mod tests {
     fn v4_on_error_tiebreak_edge_id() {
         let mut eb = edge("edge_b", "node_a");
         eb.priority = Some(10);
-        eb.on_error = Some(HashMap::from([("COMPUTATION_ERROR".into(), vec!["node_a".into()])]));
+        eb.on_error = Some(HashMap::from([(
+            "COMPUTATION_ERROR".into(),
+            vec!["node_a".into()],
+        )]));
         let mut ea = edge("edge_a", "node_b");
         ea.priority = Some(10);
-        ea.on_error = Some(HashMap::from([("COMPUTATION_ERROR".into(), vec!["node_b".into()])]));
+        ea.on_error = Some(HashMap::from([(
+            "COMPUTATION_ERROR".into(),
+            vec!["node_b".into()],
+        )]));
 
         let result = failure("COMPUTATION_ERROR");
         let edges: Vec<&Edge> = vec![&eb, &ea];
@@ -220,9 +244,15 @@ mod tests {
     #[test]
     fn v5_low_confidence_routes_via_on_error() {
         let mut e1 = edge("e1", "llm_node");
-        e1.on_error = Some(HashMap::from([("LOW_CONFIDENCE".into(), vec!["llm_node".into()])]));
+        e1.on_error = Some(HashMap::from([(
+            "LOW_CONFIDENCE".into(),
+            vec!["llm_node".into()],
+        )]));
         let mut e2 = edge("e2", "next_node");
-        e2.on_success = Some(OnSuccess { weight: Some(1.0), threshold: None });
+        e2.on_success = Some(OnSuccess {
+            weight: Some(1.0),
+            threshold: None,
+        });
 
         let result = low_confidence();
         let edges: Vec<&Edge> = vec![&e1, &e2];
@@ -232,7 +262,10 @@ mod tests {
     #[test]
     fn v6_on_success_above_threshold() {
         let mut e1 = edge("e1", "next_node");
-        e1.on_success = Some(OnSuccess { threshold: Some(0.5), weight: Some(1.0) });
+        e1.on_success = Some(OnSuccess {
+            threshold: Some(0.5),
+            weight: Some(1.0),
+        });
 
         let result = success();
         let edges: Vec<&Edge> = vec![&e1];
@@ -242,7 +275,10 @@ mod tests {
     #[test]
     fn v7_on_success_below_threshold_terminal() {
         let mut e1 = edge("e1", "next_node");
-        e1.on_success = Some(OnSuccess { threshold: Some(0.9), weight: Some(1.0) });
+        e1.on_success = Some(OnSuccess {
+            threshold: Some(0.9),
+            weight: Some(1.0),
+        });
 
         let result = success();
         let edges: Vec<&Edge> = vec![&e1];
@@ -252,7 +288,10 @@ mod tests {
     #[test]
     fn v8_on_success_no_confidence_eligible() {
         let mut e1 = edge("e1", "next_node");
-        e1.on_success = Some(OnSuccess { threshold: Some(0.9), weight: Some(1.0) });
+        e1.on_success = Some(OnSuccess {
+            threshold: Some(0.9),
+            weight: Some(1.0),
+        });
 
         let result = success();
         let edges: Vec<&Edge> = vec![&e1];
@@ -262,11 +301,20 @@ mod tests {
     #[test]
     fn v9_on_success_fanout_weight_ordering() {
         let mut e1 = edge("e1", "node_a");
-        e1.on_success = Some(OnSuccess { weight: Some(0.5), threshold: None });
+        e1.on_success = Some(OnSuccess {
+            weight: Some(0.5),
+            threshold: None,
+        });
         let mut e2 = edge("e2", "node_b");
-        e2.on_success = Some(OnSuccess { weight: Some(0.9), threshold: None });
+        e2.on_success = Some(OnSuccess {
+            weight: Some(0.9),
+            threshold: None,
+        });
         let mut e3 = edge("e3", "node_c");
-        e3.on_success = Some(OnSuccess { weight: Some(0.9), threshold: None });
+        e3.on_success = Some(OnSuccess {
+            weight: Some(0.9),
+            threshold: None,
+        });
 
         let result = success();
         let edges: Vec<&Edge> = vec![&e1, &e2, &e3];
@@ -276,24 +324,37 @@ mod tests {
     #[test]
     fn v10_on_success_weight_tiebreak_edge_id() {
         let mut ezz = edge("zz_edge", "node_a");
-        ezz.on_success = Some(OnSuccess { weight: Some(1.0), threshold: None });
+        ezz.on_success = Some(OnSuccess {
+            weight: Some(1.0),
+            threshold: None,
+        });
         let mut eaa = edge("aa_edge", "node_b");
-        eaa.on_success = Some(OnSuccess { weight: Some(1.0), threshold: None });
+        eaa.on_success = Some(OnSuccess {
+            weight: Some(1.0),
+            threshold: None,
+        });
 
         let result = success();
         let edges: Vec<&Edge> = vec![&ezz, &eaa];
-        assert_eq!(ids(&route(&edges, &result, None)), vec!["aa_edge", "zz_edge"]);
+        assert_eq!(
+            ids(&route(&edges, &result, None)),
+            vec!["aa_edge", "zz_edge"]
+        );
     }
 
     #[test]
     fn v11_invalid_confidence_routes_as_invalid_input_via_on_error() {
         let mut on_err = edge("e_err", "err_node");
-        on_err.on_error = Some(HashMap::from([
-            ("INVALID_INPUT".into(), vec!["err_node".into()])
-        ]));
+        on_err.on_error = Some(HashMap::from([(
+            "INVALID_INPUT".into(),
+            vec!["err_node".into()],
+        )]));
 
         let mut on_ok = edge("e_ok", "next");
-        on_ok.on_success = Some(OnSuccess { threshold: Some(0.5), weight: Some(1.0) });
+        on_ok.on_success = Some(OnSuccess {
+            threshold: Some(0.5),
+            weight: Some(1.0),
+        });
 
         let result = success();
         let edges: Vec<&Edge> = vec![&on_ok, &on_err];
@@ -307,9 +368,15 @@ mod tests {
     #[test]
     fn v12_nan_weight_sorted_after_finite() {
         let mut ea = edge("ea", "node_a");
-        ea.on_success = Some(OnSuccess { weight: Some(f64::NAN), threshold: None });
+        ea.on_success = Some(OnSuccess {
+            weight: Some(f64::NAN),
+            threshold: None,
+        });
         let mut eb = edge("eb", "node_b");
-        eb.on_success = Some(OnSuccess { weight: Some(0.1), threshold: None });
+        eb.on_success = Some(OnSuccess {
+            weight: Some(0.1),
+            threshold: None,
+        });
 
         let result = success();
         let edges: Vec<&Edge> = vec![&ea, &eb];
@@ -320,9 +387,15 @@ mod tests {
     #[test]
     fn v13_both_nan_weights_tiebreak_by_edge_id() {
         let mut eb = edge("eb", "node_b");
-        eb.on_success = Some(OnSuccess { weight: Some(f64::NAN), threshold: None });
+        eb.on_success = Some(OnSuccess {
+            weight: Some(f64::NAN),
+            threshold: None,
+        });
         let mut ea = edge("ea", "node_a");
-        ea.on_success = Some(OnSuccess { weight: Some(f64::NAN), threshold: None });
+        ea.on_success = Some(OnSuccess {
+            weight: Some(f64::NAN),
+            threshold: None,
+        });
 
         let result = success();
         let edges: Vec<&Edge> = vec![&eb, &ea];

--- a/runtime/src/trace.rs
+++ b/runtime/src/trace.rs
@@ -13,7 +13,9 @@ const TRACE_SCHEMA_VERSION: &str = "ncp-trace-0.1";
 pub trait TraceSink: Send {
     /// Returns false to skip all trace work (timestamp allocation, serialization).
     /// NullTrace returns false; real writers return true (default).
-    fn enabled(&self) -> bool { true }
+    fn enabled(&self) -> bool {
+        true
+    }
 
     fn emit_runtime_info(&mut self, runtime_version: &str, wasmtime_version: &str, timestamp: &str);
     fn emit_invoke(
@@ -43,13 +45,32 @@ pub trait TraceSink: Send {
 pub struct NullTrace;
 
 impl TraceSink for NullTrace {
-    fn enabled(&self) -> bool { false }
+    fn enabled(&self) -> bool {
+        false
+    }
     fn emit_runtime_info(&mut self, _: &str, _: &str, _: &str) {}
     fn emit_invoke(
-        &mut self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str,
-        _: &str, _: &str, _: &[u8], _: &str, _: u64, _: &str, _: &str,
-        _: &BrickResult, _: Option<&[u8]>, _: f64, _: &str,
-    ) {}
+        &mut self,
+        _: &str,
+        _: &str,
+        _: u64,
+        _: &str,
+        _: &str,
+        _: &str,
+        _: &str,
+        _: &str,
+        _: &str,
+        _: &[u8],
+        _: &str,
+        _: u64,
+        _: &str,
+        _: &str,
+        _: &BrickResult,
+        _: Option<&[u8]>,
+        _: f64,
+        _: &str,
+    ) {
+    }
 }
 
 // ── JsonlTraceWriter ───────────────────────────────────────────────
@@ -152,7 +173,10 @@ impl TraceSink for JsonlTraceWriter {
 
         if let Some(error) = result.error() {
             let map = record.as_object_mut().unwrap();
-            map.insert("error_class".into(), serde_json::Value::String(error.error_class.clone()));
+            map.insert(
+                "error_class".into(),
+                serde_json::Value::String(error.error_class.clone()),
+            );
         }
 
         self.write_line(&record);

--- a/runtime/src/trace.rs
+++ b/runtime/src/trace.rs
@@ -18,6 +18,11 @@ pub trait TraceSink: Send {
     }
 
     fn emit_runtime_info(&mut self, runtime_version: &str, wasmtime_version: &str, timestamp: &str);
+
+    // Rationale: invoke trace record carries every field of the §11.1 schema;
+    // the trait signature mirrors the schema 1:1 to keep call sites honest.
+    // Refactor into a TraceRecord struct in Phase 3B/3C.
+    #[allow(clippy::too_many_arguments)]
     fn emit_invoke(
         &mut self,
         trace_id: &str,
@@ -141,7 +146,7 @@ impl TraceSink for JsonlTraceWriter {
         timestamp: &str,
     ) {
         let input_hash = sha256_prefixed(envelope_bytes);
-        let output_hash = result_bytes.map(|b| sha256_prefixed(b));
+        let output_hash = result_bytes.map(sha256_prefixed);
         let result_len = result_bytes.map(|b| b.len());
 
         let mut record = serde_json::json!({

--- a/runtime/tests/smoke.rs
+++ b/runtime/tests/smoke.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Fabio Marcello Salvadori
+
+//! End-to-end smoke tests for the reference runtime.
+//!
+//! These tests load each runnable example graph from `examples/graphs/`, execute
+//! it against its committed `sample*.json` input, and verify the high-level
+//! shape of the result (success / failure / path-taken). They run as part of
+//! `cargo test -p ncp-runtime --all-targets` on every host (Linux + macOS +
+//! Windows) — see `.github/workflows/rust.yml`.
+//!
+//! Paths are derived from `env!("CARGO_MANIFEST_DIR")` so the tests are
+//! independent of the current working directory.
+//!
+//! ## Coverage
+//! - `examples/graphs/echo-pipeline/` (single-node Success)
+//! - `examples/graphs/echo-chain/` (two-node chain with on_success routing)
+//! - `examples/graphs/support-routing-stubbed/` × {positive, escalation} —
+//!   exercises the classifier → echo gate-and-escalate pattern
+//! - `examples/graphs/trap-pipeline/` (WASM trap → Failure with COMPUTATION_ERROR)
+//!
+//! ## Excluded — and why
+//! `examples/graphs/support-routing/` is intentionally NOT covered here:
+//! its `sentiment-gate` and `llm-escalation` bricks under `examples/bricks/`
+//! are fixture-only (manifest + schemas, no `.wasm` artifact). Loading the
+//! graph would fail brick resolution. The graph exists for spec illustration,
+//! not execution.
+
+use std::path::{Path, PathBuf};
+
+use ncp_runtime::result::BrickResult;
+use ncp_runtime::trace::NullTrace;
+use ncp_runtime::{ExecuteHooks, ExecuteOptions, ExecutionReport, RuntimeContext};
+
+/// Absolute path to the repository root (one level up from `runtime/`).
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("CARGO_MANIFEST_DIR has no parent — runtime/ must live under repo root")
+        .to_path_buf()
+}
+
+/// Load a graph + input from repo-relative paths and execute it once with default options.
+///
+/// Panics with a contextual message if any step fails; smoke tests are expected
+/// to load + execute cleanly.
+fn run_graph(graph_rel: &str, input_rel: &str) -> ExecutionReport {
+    let root = repo_root();
+    let graph_path = root.join(graph_rel);
+    let input_path = root.join(input_rel);
+
+    let ctx = RuntimeContext::load(&graph_path, &root.join("examples/bricks"), None)
+        .unwrap_or_else(|e| panic!("RuntimeContext::load({}) failed: {e:#}", graph_rel));
+
+    let input_text = std::fs::read_to_string(&input_path)
+        .unwrap_or_else(|e| panic!("read_to_string({}) failed: {e}", input_rel));
+    let input: serde_json::Value = serde_json::from_str(&input_text)
+        .unwrap_or_else(|e| panic!("parse JSON {} failed: {e}", input_rel));
+
+    let mut tracer = NullTrace;
+    let mut hooks = ExecuteHooks::default();
+    let opts = ExecuteOptions::default();
+
+    ctx.execute(&input, &mut tracer, &mut hooks, &opts)
+        .unwrap_or_else(|e| panic!("execute({}) failed: {e:#}", graph_rel))
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn smoke_echo_pipeline() {
+    let report = run_graph(
+        "examples/graphs/echo-pipeline/graph.yaml",
+        "examples/graphs/echo-pipeline/sample.json",
+    );
+    assert_eq!(
+        report.counts.failure, 0,
+        "echo-pipeline must not produce Failure"
+    );
+    assert!(
+        report.counts.success >= 1,
+        "echo-pipeline must produce ≥1 Success terminal; got success={}, low_confidence={}, failure={}",
+        report.counts.success, report.counts.low_confidence, report.counts.failure
+    );
+    assert!(
+        !report.terminals.is_empty(),
+        "expected at least one terminal"
+    );
+}
+
+#[test]
+fn smoke_echo_chain() {
+    let report = run_graph(
+        "examples/graphs/echo-chain/graph.yaml",
+        "examples/graphs/echo-chain/sample.json",
+    );
+    assert_eq!(
+        report.counts.failure, 0,
+        "echo-chain must not produce Failure"
+    );
+    assert!(
+        report.counts.success >= 1,
+        "echo-chain must produce ≥1 Success terminal; got success={}, low_confidence={}, failure={}",
+        report.counts.success, report.counts.low_confidence, report.counts.failure
+    );
+}
+
+#[test]
+fn smoke_support_routing_stubbed_positive() {
+    let report = run_graph(
+        "examples/graphs/support-routing-stubbed/graph.yaml",
+        "examples/graphs/support-routing-stubbed/sample-positive.json",
+    );
+    assert_eq!(
+        report.counts.failure, 0,
+        "positive path must not produce Failure"
+    );
+    assert!(report.counts.success >= 1);
+    assert!(!report.terminals.is_empty());
+
+    // Positive: classifier returns Success → terminal at the classifier
+    // (no escalation edge taken). Order-independent: just verify some
+    // terminal lives on the classifier brick.
+    assert!(
+        report
+            .terminals
+            .iter()
+            .any(|t| t.brick_id.contains("classifier")),
+        "positive path should terminate at the classifier brick; terminals={:?}",
+        report
+            .terminals
+            .iter()
+            .map(|t| &t.brick_id)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn smoke_support_routing_stubbed_escalation() {
+    let report = run_graph(
+        "examples/graphs/support-routing-stubbed/graph.yaml",
+        "examples/graphs/support-routing-stubbed/sample.json",
+    );
+    assert_eq!(
+        report.counts.failure, 0,
+        "escalation path must not produce Failure (echo always succeeds)"
+    );
+    assert!(report.counts.success >= 1);
+    assert!(!report.terminals.is_empty());
+
+    // Escalation: classifier emits LowConfidence → on_error edge routes to
+    // echo → terminal at echo. Order-independent.
+    assert!(
+        report.terminals.iter().any(|t| t.brick_id.contains("echo")),
+        "escalation path should terminate at the echo brick; terminals={:?}",
+        report
+            .terminals
+            .iter()
+            .map(|t| &t.brick_id)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn smoke_trap_pipeline_fails_as_designed() {
+    let report = run_graph(
+        "examples/graphs/trap-pipeline/graph.yaml",
+        "examples/graphs/trap-pipeline/sample.json",
+    );
+    assert_eq!(
+        report.counts.success, 0,
+        "trap-pipeline must not produce Success"
+    );
+    assert!(
+        report.counts.failure >= 1,
+        "trap-pipeline must produce ≥1 Failure terminal; got success={}, low_confidence={}, failure={}",
+        report.counts.success, report.counts.low_confidence, report.counts.failure
+    );
+    assert!(!report.terminals.is_empty());
+
+    // Trap → runtime catches → Failure { error }. We intentionally do NOT pin
+    // `error_class` to a specific string (e.g. "COMPUTATION_ERROR"): trap
+    // classification can drift across Wasmtime versions. The two stable
+    // invariants are (a) some terminal IS a Failure, and (b) it carries a
+    // non-empty error_class. We grab any Failure terminal — terminal ordering
+    // is not a test invariant.
+    let failure = report
+        .terminals
+        .iter()
+        .find(|t| matches!(&t.result, BrickResult::Failure { .. }))
+        .expect("expected at least one Failure terminal");
+
+    match &failure.result {
+        BrickResult::Failure { error } => assert!(
+            !error.error_class.is_empty(),
+            "Failure terminal must carry a non-empty error_class"
+        ),
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
## Summary

PR B of 4 for Phase 3.0 (Release Hygiene). Adds the Rust CI workflow + cross-platform smoke integration tests. After this merges, every push to `main` is gated on fmt, clippy `-D warnings`, full `cargo test` on three OSes, and a `wasm-build` job for the brick crates.

Structured as **3 commits**:
1. `35073b4` — `style: rustfmt (cargo fmt --all)` — mechanical reformat of existing Rust files; **zero behavior change**. Required so the new fmt gate passes.
2. `a85f957` — `fix: satisfy cargo clippy -D warnings (Rust 1.94.0)` — pre-existing-code clippy fixes; **zero behavior change**. Five mechanical cleanups + three function-scoped `#[allow(clippy::too_many_arguments)]` with rationale comments (envelope builder, trace emit_invoke trait method, CLI dispatch shim). Required so the new clippy gate passes.
3. `632754c` — `ci(rust): cross-platform workflow + smoke integration tests` — the actual Phase 3.0 payload.

## ⚠️ PR C will require these EXACT check contexts (verbatim, case-sensitive)

These are the names PR C binds in the branch protection ruleset. Any change to the workflow `name:` or job keys here MUST be mirrored in PR C's ruleset edit, or PRs will block forever waiting on phantom check contexts:

- `Rust / fmt`
- `Rust / clippy`
- `Rust / test (ubuntu-24.04)`
- `Rust / test (macos-14)`
- `Rust / test (windows-2022)`
- `Rust / wasm-build`

## Files

**Commit 1 (rustfmt — 12 files):** `bricks/{classifier-stub,echo}/src/lib.rs`, `runtime/src/{bin/ncp-bench,engine,envelope,lib,main,mapping,resolver,result,router,trace}.rs`.

**Commit 2 (clippy — 6 files):** `runtime/src/{envelope,lib,main,resolver,router,trace}.rs`.

**Commit 3 (new — 2 files):**
- `.github/workflows/rust.yml` — fmt + clippy on Linux; `cargo test -p ncp-runtime --all-targets --locked` on `ubuntu-24.04` / `macos-14` / `windows-2022`; `wasm-build` job for `ncp-echo` and `ncp-classifier-stub` on `wasm32-unknown-unknown`. All cargo invocations use `--locked`; per-job `timeout-minutes`; explicit `permissions:` block; CI-invariants comment block at top.
- `runtime/tests/smoke.rs` — 5 integration tests using `RuntimeContext::load` + `.execute` against every runnable example graph. Paths via `env!("CARGO_MANIFEST_DIR")`. Trap-pipeline test asserts only `Failure` + non-empty `error_class` (no specific class pinned — robust to Wasmtime drift).

## Test plan

- [ ] DCO check passes on all 3 commits
- [ ] Existing `validate` workflow stays green (Node 20 + Node 22 + wasm-digest-check)
- [ ] New `Rust` workflow runs and reports all 6 contexts listed above
- [ ] All 6 Rust contexts pass on first run
- [ ] Eyeball: only the 14 files listed above are touched

## Verified locally on Windows
- `cargo fmt --all -- --check` ✅
- `cargo clippy -p ncp-runtime --all-targets --locked -- -D warnings` ✅
- `cargo test -p ncp-runtime --all-targets --locked` ✅ (44 unit + 5 smoke = 49 tests)
- `cargo build -p ncp-echo --target wasm32-unknown-unknown --release --locked` ✅
- `cargo build -p ncp-classifier-stub --target wasm32-unknown-unknown --release --locked` ✅

Part of Phase 3.0 — see [docs/ROADMAP.md](docs/ROADMAP.md) §2.