### PR TITLE
release: prepare v0.3.3 — crate-version alignment + changelog finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the NCP specification and its reference tooling
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Brick versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). NCP protocol versions follow the versioning policy in the spec (v0.2.x patch-compatible, breaking changes require v0.3.0).
 
-## [0.3.3] — 2026-05-XX
+## [0.3.3] — 2026-05-26
 
 ### Added
 - **Rust CI workflow** (`.github/workflows/rust.yml`): fmt, clippy with `-D warnings`,
@@ -40,6 +40,16 @@ Brick versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `run` subcommand (previously copy-pasted commands failed with
   `unrecognized argument`). `ncp-bench` invocations unaffected (positional graph
   argument, no subcommand)
+
+### Changed
+- `runtime/Cargo.toml`: crate version bumped `0.1.0` → `0.3.3` to align with
+  the release tag and eliminate the `cargo install ncp-runtime` version
+  surprise. `Cargo.lock` updated to match (only the self-version entry).
+- Brick crates (`ncp-echo`, `ncp-classifier-stub`) intentionally remain at
+  crate version `0.1.0`. Their Rust crate version is decoupled from the
+  NCP-brick-manifest version (declared in `examples/bricks/*/manifest.yaml`,
+  also `0.1.0`). The two will align when bricks are published to crates.io
+  in Phase 3A.
 
 ## [0.3.2] — 2026-04-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "ncp-runtime"
-version = "0.1.0"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ncp-runtime"
-version = "0.1.0"
+version = "0.3.3"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

**PR D of 4** for Phase 3.0 (Release Hygiene) — the final piece. After this merges, the release ceremony (signed tag + GitHub Release + Zenodo auto-archive) follows in a separate set of commands run by the maintainer.

## Changes (3 files)

- **`runtime/Cargo.toml`**: `version = "0.1.0"` → `"0.3.3"`. Aligns the runtime crate's self-declared version with the upcoming release tag — eliminates the `cargo install ncp-runtime` version surprise that Phase 3A packaging would otherwise hit. Brick crates (`ncp-echo`, `ncp-classifier-stub`) stay at `0.1.0` deliberately; their Rust crate versions are decoupled from the NCP brick-manifest versions (also `0.1.0`) and will align when bricks publish to crates.io in Phase 3A.
- **`Cargo.lock`**: auto-updated by `cargo check` to match the runtime crate's new self-version. Diff is 1 line — only the `[[package]] name = "ncp-runtime"` entry's `version` field changed; no dependency-tree changes.
- **`CHANGELOG.md`**: filled `2026-05-XX` placeholder → `2026-05-26`; added `### Changed` section documenting the version-bump rationale and brick-crate decoupling.

## Test plan

- [ ] DCO check ✅
- [ ] All 4 pre-existing required checks (validate ×2, wasm-digest-check + DCO) pass
- [ ] All 6 Rust CI contexts (fmt, clippy, test ×3 OSes, wasm-build) pass — first PR where these are *required-gates* in the ruleset (PR C bound them after merging here)
- [ ] `cargo install ncp-runtime` (when published in Phase 3A) will report version `0.3.3`

## After merge — release ceremony

1. Sync local main, delete this branch.
2. Verify Zenodo GitHub integration is still enabled (dashboard).
3. Signed tag on the merge commit:
   ```bash
   git tag -s v0.3.3 -m "v0.3.3 — Release Hygiene"
   git push origin v0.3.3
   ```
4. GitHub Release via `gh release create v0.3.3 --notes-file RELEASE_NOTES_v0.3.3.md` (notes drafted from this entry's CHANGELOG content).
5. Verify Zenodo auto-archives the release under concept DOI `10.5281/zenodo.19570209` (~5 min).

Verified locally on Windows: fmt + host clippy + 49 tests (44 unit + 5 smoke) + wasm32-unknown-unknown builds of both brick crates, all green under `--locked`.

Part of Phase 3.0 — see [docs/ROADMAP.md](docs/ROADMAP.md) §2.