### PR TITLE
docs(install): install matrix + crates.io publish metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ All notable changes to the NCP specification and its reference tooling
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Brick versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). NCP protocol versions follow the versioning policy in the spec (v0.2.x patch-compatible, breaking changes require v0.3.0).
 
+## [0.3.4] — 2026-MM-DD
+
+### Added
+- **`docs/INSTALL.md`**: install matrix for adopters — GitHub Releases archives,
+  Docker (GHCR), `cargo install` from crates.io, and build-from-source — each
+  with per-OS commands and checksum verification. Architecture coverage table
+  at top makes Apple Silicon vs Intel + Linux x86_64 vs aarch64 self-service
+- **`runtime/Cargo.toml`** crates.io publish metadata: `description`,
+  `repository`, `homepage`, `readme = "../README.md"`, `keywords` (`wasm`,
+  `agentic-ai`, `graph`, `deterministic`, `ncp`), `categories` (`wasm`,
+  `command-line-utilities`, `asynchronous`), and explicit `include` array.
+  Verified end-to-end via `cargo publish --dry-run --locked` and unpacked-crate
+  `cargo install --path . --bin ncp --locked` (produces working `ncp` binary)
+- **`runtime/LICENSE`** + **`runtime/NOTICE`**: verbatim copies of the
+  repo-root files. Cargo's `include` array silently strips `..` paths, so
+  local copies are needed for Apache 2.0 §4(d) compliance in the published
+  `.crate` (`readme = "../README.md"` continues to work because cargo
+  special-cases the `readme` field)
+- **`README.md`**: top-level "Install" section above "Quick start", linking
+  to `docs/INSTALL.md`. Pre-built install paths are now the default story;
+  building from source is positioned as the developer path
+
 ## [0.3.3] — 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ These results are measured end-to-end by cycling a dataset (`--dataset`) so the 
 
 ---
 
+## Install
+
+Three ways to get a working `ncp` CLI — full matrix (per-OS commands, checksums, architecture coverage) in [`docs/INSTALL.md`](docs/INSTALL.md):
+
+- **Download** a release archive: https://github.com/madeinplutofabio/neural-computation-protocol/releases/latest
+- **Docker** (Linux x86_64): `docker run --rm ghcr.io/madeinplutofabio/ncp:v0.3.4 --version`
+- **`cargo install`** (any platform with Rust 1.94+): `cargo install ncp-runtime --bin ncp --locked`
+
+For developers building from source, see [Quick start](#quick-start-runtime) below.
+
+---
+
 ## Quick start (runtime)
 
 Prereqs: **Rust 1.94+**.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,125 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 Fabio Marcello Salvadori
+-->
+
+# Installing NCP
+
+Three ways to get a working `ncp` CLI in under 5 minutes. Pick the one that fits your OS + arch.
+
+## Architecture coverage
+
+| OS / arch | GitHub Release archive | Docker | `cargo install` |
+|---|---|---|---|
+| Linux x86_64 | ✅ `ncp_v0.3.4_linux_x86_64.tar.gz` | ✅ `ghcr.io/madeinplutofabio/ncp:v0.3.4` | ✅ |
+| Linux aarch64 | ❌ ([Phase 3C](ROADMAP.md#5-phase-3c--production-profile-hardening-track)) | ❌ ([Phase 3C](ROADMAP.md#5-phase-3c--production-profile-hardening-track)) | ✅ |
+| macOS aarch64 (Apple Silicon, M1+) | ✅ `ncp_v0.3.4_macos_aarch64.tar.gz` | n/a | ✅ |
+| **macOS x86_64 (Intel)** | ❌ ([Phase 3C](ROADMAP.md#5-phase-3c--production-profile-hardening-track)) | n/a | ✅ |
+| Windows x86_64 | ✅ `ncp_v0.3.4_windows_x86_64.zip` | n/a | ✅ |
+
+**Note for macOS Intel users:** the release archive targets Apple Silicon only. Use `cargo install` (below) or build from source. Multi-arch coverage is on the [roadmap](ROADMAP.md#5-phase-3c--production-profile-hardening-track) for Phase 3C.
+
+---
+
+## Option 1 — Download from GitHub Releases (no toolchain required)
+
+1. Go to https://github.com/madeinplutofabio/neural-computation-protocol/releases/latest
+2. Download the archive matching your platform (see table above).
+3. Verify the checksum against `SHA256SUMS` (also attached to the release):
+
+   **Linux / macOS:**
+   ```bash
+   shasum -a 256 -c SHA256SUMS --ignore-missing
+   ```
+
+   **Windows (PowerShell):**
+   ```powershell
+   Get-FileHash -Algorithm SHA256 ncp_v0.3.4_windows_x86_64.zip
+   # Compare the output against the line for windows_x86_64 in SHA256SUMS
+   ```
+
+4. Extract:
+
+   **Linux / macOS:**
+   ```bash
+   tar -xzf ncp_v0.3.4_<platform>.tar.gz
+   cd ncp_v0.3.4_<platform>
+   ```
+
+   **Windows:**
+   ```powershell
+   Expand-Archive ncp_v0.3.4_windows_x86_64.zip
+   cd ncp_v0.3.4_windows_x86_64
+   ```
+
+5. Run a quick verify (see **Quick verify** at the bottom of this doc).
+
+Each archive contains the `ncp` binary, the `examples/` tree, plus `LICENSE`, `NOTICE`, and `README.md`.
+
+---
+
+## Option 2 — Docker (Linux x86_64)
+
+```bash
+docker pull ghcr.io/madeinplutofabio/ncp:v0.3.4
+docker run --rm ghcr.io/madeinplutofabio/ncp:v0.3.4 --version
+```
+
+Image base is `gcr.io/distroless/cc-debian12:nonroot` (~25 MB). The image bakes in `/app/examples/` so you can run example graphs without mounting anything. See **Quick verify** below.
+
+Image tags are strict-pin only — there's no `:latest` and no floating `:0.3` tag. Always specify a full version.
+
+---
+
+## Option 3 — `cargo install` from crates.io
+
+Requires Rust 1.94+ (the project's pinned toolchain).
+
+```bash
+cargo install ncp-runtime --bin ncp --locked
+ncp --version
+```
+
+`--locked` ensures cargo uses the exact dependency versions that shipped with the release (the lockfile travels inside the `.crate` for binary packages).
+
+The crates.io package installs only the `ncp` binary — `examples/` are NOT included. To run the quick-verify example, either:
+- Clone the repo: `git clone https://github.com/madeinplutofabio/neural-computation-protocol.git && cd neural-computation-protocol`
+- Or download just the examples from a GitHub Release archive.
+
+---
+
+## Option 4 — Build from source
+
+```bash
+git clone https://github.com/madeinplutofabio/neural-computation-protocol.git
+cd neural-computation-protocol
+cargo build -p ncp-runtime --release --bin ncp
+./target/release/ncp --version
+```
+
+For the full developer workflow (running tests, building bricks, benchmarks), see [`docs/ADOPTION_GUIDE.md`](ADOPTION_GUIDE.md).
+
+---
+
+## Quick verify
+
+Run the deterministic echo example on any install path:
+
+```bash
+ncp run examples/graphs/echo-pipeline/graph.yaml --input examples/graphs/echo-pipeline/sample.json
+```
+
+(From within the extracted archive, the cloned repo, or the Docker image's working directory.)
+
+Expected: a JSON result emitted to stdout with a `Success` terminal. If you see that, your install works.
+
+For more end-to-end tutorials (tracing, the hybrid-routing demo, embedding `ncp` as a library), see [`docs/ADOPTION_GUIDE.md`](ADOPTION_GUIDE.md).
+
+---
+
+## Next steps
+
+- **Adopting NCP in your stack:** [`docs/ADOPTION_GUIDE.md`](ADOPTION_GUIDE.md)
+- **Benchmark methodology + numbers:** [`BENCHMARK.md`](../BENCHMARK.md)
+- **Phase roadmap:** [`docs/ROADMAP.md`](ROADMAP.md)
+- **Contributing:** [`CONTRIBUTING.md`](../CONTRIBUTING.md)

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,6 +5,19 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 default-run = "ncp"
+description = "NCP reference runtime — composable, auditable WASM agent graphs"
+repository = "https://github.com/madeinplutofabio/neural-computation-protocol"
+homepage = "https://github.com/madeinplutofabio/neural-computation-protocol"
+readme = "../README.md"
+keywords = ["wasm", "agentic-ai", "graph", "deterministic", "ncp"]
+categories = ["wasm", "command-line-utilities", "asynchronous"]
+include = [
+    "src/**",
+    "tests/**",
+    "Cargo.toml",
+    "LICENSE",
+    "NOTICE",
+]
 
 [lib]
 name = "ncp_runtime"

--- a/runtime/LICENSE
+++ b/runtime/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Fabio Marcello Salvadori
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/runtime/NOTICE
+++ b/runtime/NOTICE
@@ -1,0 +1,7 @@
+NCP — Neural Computation Protocol
+Copyright 2026 Fabio Marcello Salvadori
+
+This product includes software developed by Fabio Marcello Salvadori.
+
+Licensed under the Apache License, Version 2.0.
+See the LICENSE file for the full license text.


### PR DESCRIPTION
## Summary

**PR A of 4** for Phase 3A.1 (Distribution). Lays the groundwork for the v0.3.4 release ceremony:
1. Tells adopters how to install (`docs/INSTALL.md`).
2. Makes the `ncp-runtime` crate publishable to crates.io (`runtime/Cargo.toml` metadata + local LICENSE/NOTICE for Apache 2.0 §4(d) compliance).

No Rust source code touched. No new workflows. No version bump. Each of those is a later PR in this phase.

## Files

**Added:**
- `docs/INSTALL.md` — install matrix covering GitHub Releases archives, Docker (GHCR), `cargo install` from crates.io, and build-from-source. Architecture coverage table at top makes Apple Silicon vs Intel + Linux x86_64 vs aarch64 self-service (Linux aarch64 + macOS Intel deferred to Phase 3C).
- `runtime/LICENSE` + `runtime/NOTICE` — verbatim copies of repo-root files. Cargo's `include` array silently strips `..` paths (verified empirically during the dry-run gate), so local copies are needed for Apache 2.0 §4(d) compliance in the published `.crate`.

**Modified:**
- `runtime/Cargo.toml` — crates.io publish metadata: `description`, `repository`, `homepage`, `readme = "../README.md"` (workspace-relative — cargo special-cases the `readme` field), `keywords` (`wasm`, `agentic-ai`, `graph`, `deterministic`, `ncp`), `categories` (`wasm`, `command-line-utilities`, `asynchronous`), and explicit `include` array.
- `README.md` — top-level **Install** section above existing **Quick start (runtime)**, linking to `docs/INSTALL.md`. Pre-built install paths now the default story; building from source positioned as the developer path.
- `CHANGELOG.md` — v0.3.4 stub with the changes above. Date placeholder `2026-MM-DD` filled by PR D (same pattern as Phase 3.0 PR D).

## Package-layout decision (Hybrid Option — empirically determined)

| Field | Approach | Why |
|---|---|---|
| `readme` | `"../README.md"` (workspace-relative) | Cargo special-cases `readme` and copies the file into the .crate as `README.md`. No README duplication. |
| `include` | Local `"LICENSE"` + `"NOTICE"` | Cargo's `include` array silently strips `..` paths. Pure-Option-1 with `"../LICENSE"`/`"../NOTICE"` would have shipped a .crate missing NOTICE — Apache §4(d) violation. |

This is documented in the plan file's "Package layout strategy" section + in the PR-A commit body for future maintainers.

## Verification (local, on Windows)

| Gate | Command | Result |
|---|---|---|
| Package contents | `cargo package -p ncp-runtime --list --allow-dirty` | ✅ Includes `README.md`, `LICENSE`, `NOTICE` |
| Publish dry-run | `cargo publish -p ncp-runtime --dry-run --locked --allow-dirty` | ✅ exit 0 (21 files, 52.0 KiB compressed) |
| End-user install | Unpack `.crate` → `cargo install --path . --bin ncp --locked --force` | ✅ exit 0, ~75s build |
| Installed binary | `ncp --version` | ✅ prints `ncp 0.3.3` (pre-bump; v0.3.4 in PR D) |

## Test plan
- [ ] DCO check ✅
- [ ] All 10 required checks pass (existing CI: validate ×2, wasm-digest-check, DCO; Rust workflow: fmt, clippy, test ×3 OSes, wasm-build) — this PR is docs + Cargo metadata only, no Rust source change, so all expected to pass
- [ ] `runtime/LICENSE` + `runtime/NOTICE` confirmed byte-identical to repo-root via `diff -q` (validated locally)
- [ ] `docs/INSTALL.md` links render correctly on github.com (anchor `#5-phase-3c--production-profile-hardening-track` resolves to ROADMAP.md's Phase 3C section)

## Not in this PR (deferred)

| Item | Where |
|---|---|
| `.github/workflows/release.yml` (per-OS archives + SHA256SUMS) | PR B |
| `Dockerfile` + `.github/workflows/docker.yml` (GHCR image) | PR C |
| `runtime/Cargo.toml` version bump 0.3.3 → 0.3.4 | PR D |
| Full `docs/PUBLISHING.md` (crates.io section) | PR B starts it (tag/release ceremony), PR D extends with cargo publish steps |

Part of Phase 3A.1 — see [docs/ROADMAP.md](docs/ROADMAP.md) §3.