### PR TITLE
ci(release): release workflow + tag/release ceremony doc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+#
+# RELEASE WORKFLOW INVARIANTS
+#   - Triggers: push to tags matching 'v*' OR workflow_dispatch with `tag` input.
+#   - workflow_dispatch defaults to publish=false (builds archives as workflow
+#     artifacts only, does NOT create/edit a GitHub Release). Set publish=true
+#     to actually publish. This guards against dispatched runs against existing
+#     tags mutating their already-published Releases.
+#   - `publish` is a `type: choice` (string) input, NOT `type: boolean`, so the
+#     `if:` gate below can use unambiguous `== 'true'` comparison. With a
+#     boolean type, the gate `&& inputs.publish` would be truthy for ANY
+#     non-empty string (including the string 'false'), which is the nightmare
+#     scenario: publish job runs when we think it won't.
+#   - actions/checkout MUST use `ref: ${{ inputs.tag || github.ref }}` so
+#     workflow_dispatch builds the requested tag, NOT main's HEAD.
+#   - Do NOT rebuild brick WASM artifacts during packaging. Use the committed
+#     examples/bricks/**/*.wasm verbatim (already digest-gated by validate.yml's
+#     wasm-digest-check on every PR/push to main).
+#   - Per-OS archive naming: ncp_<tag>_<os_label>_<arch>.<ext>
+#     - linux:   ncp_<tag>_linux_x86_64.tar.gz
+#     - macos:   ncp_<tag>_macos_aarch64.tar.gz
+#     - windows: ncp_<tag>_windows_x86_64.zip
+#   - This workflow's jobs trigger only on push:tags + workflow_dispatch — never
+#     pull_request — so the job names are NOT bound by branch-protection ruleset.
+#   - Pre-release tags (v*-rc.*, v*-alpha.*, v*-beta.*) auto-marked as
+#     GitHub Release prerelease=true; full versions as prerelease=false.
+
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v0.3.4 or v0.3.4-rc.1)'
+        required: true
+        type: string
+      publish:
+        description: 'Create/update GitHub Release? (false = artifacts only)'
+        required: false
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-build:
+    name: build (${{ matrix.os_label }}-${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            os_label: linux
+            arch: x86_64
+            ext: tar.gz
+            bin: ncp
+          - os: macos-14
+            os_label: macos
+            arch: aarch64
+            ext: tar.gz
+            bin: ncp
+          - os: windows-2022
+            os_label: windows
+            arch: x86_64
+            ext: zip
+            bin: ncp.exe
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.os }}
+
+      - name: Build ncp (release, --locked)
+        run: cargo build -p ncp-runtime --release --locked --bin ncp
+
+      - name: Stage archive contents (Unix)
+        if: matrix.ext == 'tar.gz'
+        shell: bash
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          STAGE="ncp_${TAG}_${{ matrix.os_label }}_${{ matrix.arch }}"
+          mkdir -p "$STAGE/examples"
+          cp "target/release/${{ matrix.bin }}" "$STAGE/"
+          cp -r examples/graphs "$STAGE/examples/"
+          cp -r examples/bricks "$STAGE/examples/"
+          cp LICENSE NOTICE README.md "$STAGE/"
+          echo "--- $STAGE contents ---"
+          find "$STAGE" -type f | head -50
+          echo "STAGE=$STAGE" >> "$GITHUB_ENV"
+
+      - name: Pack tar.gz (Unix)
+        if: matrix.ext == 'tar.gz'
+        shell: bash
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          ARCHIVE="ncp_${TAG}_${{ matrix.os_label }}_${{ matrix.arch }}.tar.gz"
+          tar -czf "$ARCHIVE" "$STAGE"
+          ls -la "$ARCHIVE"
+          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
+
+      - name: Stage archive contents (Windows)
+        if: matrix.ext == 'zip'
+        shell: pwsh
+        run: |
+          $TAG = "${{ inputs.tag || github.ref_name }}"
+          $STAGE = "ncp_${TAG}_${{ matrix.os_label }}_${{ matrix.arch }}"
+          New-Item -ItemType Directory -Path $STAGE | Out-Null
+          New-Item -ItemType Directory -Path "$STAGE/examples" | Out-Null
+          Copy-Item "target/release/${{ matrix.bin }}" "$STAGE/"
+          Copy-Item -Recurse "examples/graphs" "$STAGE/examples/graphs"
+          Copy-Item -Recurse "examples/bricks" "$STAGE/examples/bricks"
+          Copy-Item "LICENSE","NOTICE","README.md" "$STAGE/"
+          Write-Host "--- $STAGE contents ---"
+          Get-ChildItem -Recurse $STAGE | Select-Object -First 50 FullName
+          "STAGE=$STAGE" | Add-Content -Path $env:GITHUB_ENV
+
+      - name: Pack zip (Windows)
+        if: matrix.ext == 'zip'
+        shell: pwsh
+        run: |
+          $TAG = "${{ inputs.tag || github.ref_name }}"
+          $ARCHIVE = "ncp_${TAG}_${{ matrix.os_label }}_${{ matrix.arch }}.zip"
+          Compress-Archive -Path $env:STAGE -DestinationPath $ARCHIVE
+          Get-Item $ARCHIVE | Format-List
+          "ARCHIVE=$ARCHIVE" | Add-Content -Path $env:GITHUB_ENV
+
+      - name: Upload archive as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: archive-${{ matrix.os_label }}-${{ matrix.arch }}
+          path: ${{ env.ARCHIVE }}
+          if-no-files-found: error
+          retention-days: 90
+
+  release-publish:
+    name: publish (release)
+    needs: release-build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Download all archive artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: archive-*
+          merge-multiple: true
+
+      - name: Generate SHA256SUMS
+        shell: bash
+        run: |
+          cd dist
+          ls -la
+          sha256sum ncp_*.tar.gz ncp_*.zip > SHA256SUMS
+          echo "--- SHA256SUMS ---"
+          cat SHA256SUMS
+
+      - name: Create / update GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          prerelease: ${{ contains(inputs.tag || github.ref_name, '-rc.') || contains(inputs.tag || github.ref_name, '-beta.') || contains(inputs.tag || github.ref_name, '-alpha.') }}
+          files: |
+            dist/ncp_*.tar.gz
+            dist/ncp_*.zip
+            dist/SHA256SUMS

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,166 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 Fabio Marcello Salvadori
+-->
+
+# Publishing a release
+
+End-to-end ceremony for cutting a new NCP version. This is the maintainer-facing
+companion to [`docs/INSTALL.md`](INSTALL.md) (which is adopter-facing).
+
+> **Phase 3A.1 build-out:** this doc is added incrementally across three PRs.
+> - **PR B (this PR)** — Sections 1–6: tag preparation, signed-tag creation,
+>   `Release` workflow ceremony, RC test-tag flow.
+> - **PR C** — Section 7: GHCR Docker image publish (added when the Docker
+>   workflow lands).
+> - **PR D** — Section 8: `cargo publish` to crates.io (added when the
+>   runtime crate version bumps to 0.3.4).
+> When all three PRs ship, this doc covers the full ceremony.
+
+---
+
+## 1. Prerequisites
+
+| Need | How to verify |
+|---|---|
+| GPG key configured for signed tags | `git config --get user.signingkey` returns a non-empty key ID. Verify the key still works: `echo test \| gpg --clearsign` should prompt for passphrase and produce a signed block. |
+| Push access to `main` + tag push permission | `gh auth status` shows the active account with `repo` scope. |
+| `gh` CLI authenticated | `gh auth status` clean. |
+| Zenodo integration ON for the repo | Visit https://zenodo.org/account/settings/github/ — toggle for `madeinplutofabio/neural-computation-protocol` is **enabled**. |
+| Working tree clean on latest `main` | `git status -sb` shows `## main...origin/main` with no modifications. |
+
+## 2. Confirm release state
+
+Before tagging, the next-release version must already be on `main`:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+grep '^version' runtime/Cargo.toml        # should match the upcoming tag (no leading v)
+grep '^## \[' CHANGELOG.md | head -3       # latest entry should be the upcoming version
+```
+
+If the version still shows the previous release (e.g. `0.3.3` when you're trying
+to cut `v0.3.4`), **STOP** — PR D's version-bump didn't land. Tagging now would
+produce binaries that report the wrong `ncp --version`.
+
+## 3. Dry-run the release workflow against an existing tag (optional but recommended)
+
+The `Release` workflow accepts a `workflow_dispatch` input with `publish=false`
+(default), which lets you exercise the build matrix without touching any
+existing GitHub Release.
+
+```bash
+gh workflow run release.yml \
+  -f tag=v0.3.3 \
+  -f publish=false
+```
+
+Then check the run:
+
+```bash
+gh run list --workflow release.yml --limit 1
+```
+
+When complete, all 3 archive artifacts should be downloadable from the Actions
+run page. Verify the `v0.3.3` GitHub Release page is **unchanged** (no new
+assets). If `publish=false` ever produces assets on the existing Release, that's
+a workflow bug — file an issue.
+
+## 4. Push a pre-release tag (RC)
+
+Pre-release tags (`v*-rc.*`, `v*-alpha.*`, `v*-beta.*`) are auto-marked as
+GitHub `prerelease=true` by the workflow. This lets you exercise the full
+release path end-to-end before committing to a real version.
+
+```bash
+TAG="v0.3.4-rc.1"
+git tag -s "$TAG" -m "$TAG release candidate"
+git push origin "$TAG"
+```
+
+The push fires the `Release` workflow (no dispatch needed — push to `v*` always
+publishes). Watch progress:
+
+```bash
+gh run watch
+```
+
+Expected outputs once the workflow completes:
+
+- A GitHub Release at `https://github.com/madeinplutofabio/neural-computation-protocol/releases/tag/v0.3.4-rc.1`, **marked "Pre-release"**.
+- 4 assets attached: 3 archives + `SHA256SUMS`.
+  - `ncp_v0.3.4-rc.1_linux_x86_64.tar.gz`
+  - `ncp_v0.3.4-rc.1_macos_aarch64.tar.gz`
+  - `ncp_v0.3.4-rc.1_windows_x86_64.zip`
+  - `SHA256SUMS`
+
+## 5. Verify the pre-release artifacts
+
+```bash
+mkdir -p /tmp/ncp-rc-verify && cd /tmp/ncp-rc-verify
+gh release download v0.3.4-rc.1 --repo madeinplutofabio/neural-computation-protocol
+
+# Verify checksums
+shasum -a 256 -c SHA256SUMS --ignore-missing
+
+# Extract one archive and run a quick verify
+tar -xzf ncp_v0.3.4-rc.1_linux_x86_64.tar.gz   # adjust for your platform
+cd ncp_v0.3.4-rc.1_linux_x86_64
+./ncp --version    # should print the version (without -rc.1 — cargo's package version)
+./ncp run examples/graphs/echo-pipeline/graph.yaml --input examples/graphs/echo-pipeline/sample.json
+```
+
+If anything fails: do NOT proceed to step 6. Debug the workflow, fix, retag a
+new RC (`v0.3.4-rc.2`), and re-verify.
+
+## 6. Clean up the RC tag and push the real tag
+
+Once the RC verifies clean, delete the RC artifacts before cutting the real tag.
+Leaving an RC tag pullable indefinitely confuses adopters.
+
+```bash
+RC="v0.3.4-rc.1"
+gh release delete "$RC" --yes
+git push origin --delete "$RC"
+git tag -d "$RC"
+```
+
+> **PR C will extend this section** with `gh api`-based GHCR Docker tag cleanup
+> (each release publishes two GHCR tags; both must be deleted on RC cleanup).
+
+Then push the real tag:
+
+```bash
+TAG="v0.3.4"
+git tag -s "$TAG" -m "$TAG"
+git push origin "$TAG"
+gh run watch    # follow the Release workflow
+```
+
+The workflow produces the same artifact set as the RC, this time on a
+**non-prerelease** GitHub Release.
+
+## 6.1 Verify Zenodo auto-archive (~3-5 min after release publishes)
+
+Zenodo's GitHub integration archives every GitHub Release into the project's
+concept DOI record. Verify:
+
+```bash
+# Concept DOI (stable, points to "latest"):
+echo "https://doi.org/10.5281/zenodo.19570209"
+```
+
+Open the URL. The latest version should match the tag you just pushed. If
+Zenodo doesn't update within ~10 minutes, check the integration page (see
+Section 1's Prerequisites table) — the webhook may have been disabled.
+
+---
+
+## Sections coming in PR C / PR D
+
+- **§7 — GHCR Docker image** (PR C) — `docker.yml` workflow + image tag cleanup.
+- **§8 — `cargo publish` to crates.io** (PR D) — pre-flight `cargo publish --dry-run`, manual publish command, README link audit on crates.io render.
+
+When all three PRs ship, this doc is the single canonical reference for the
+full release ceremony.


### PR DESCRIPTION
## Summary

**PR B of 4** for Phase 3A.1 (Distribution). Adds the GitHub Actions workflow that turns a `v*` git tag into a published GitHub Release with per-OS archives + `SHA256SUMS`, and starts the operator-facing `docs/PUBLISHING.md` (extended in PRs C and D).

No Rust source code or Cargo.toml changes. The new workflow does NOT run on this PR — it triggers only on `push: tags: ['v*']` + `workflow_dispatch`, never `pull_request`. First real fire is during the Phase 3A.1 release ceremony.

## Files

**Added:**
- `.github/workflows/release.yml` (176 lines)
- `docs/PUBLISHING.md` (165 lines, partial — sections 1-6 only; PR C adds §7, PR D adds §8)

## Workflow design (matches plan)

| Decision | Where |
|---|---|
| Triggers: `push: tags: ['v*']` + `workflow_dispatch` (with `tag` + `publish` inputs) | release.yml lines 26-41 |
| `publish: false` default for dispatch (artifact-only mode) | lines 38-41 |
| `permissions: contents: read` workflow-level (least privilege) | line 43 |
| `permissions: contents: write` on `release-publish` only (override) | line 122 |
| `concurrency.cancel-in-progress: false` | line 47 |
| Matrix: ubuntu-24.04 + macos-14 + windows-2022 with platform tuples | lines 55-58 |
| Explicit `actions/checkout` `ref: ${{ inputs.tag \|\| github.ref }}` on both jobs | lines 63, 129 |
| `dtolnay/rust-toolchain@stable` + `toolchain: 1.94.0` | lines 67-68 |
| `cargo build … --locked` | line 75 |
| OS-specific staging via `if: matrix.ext == ...` | lines 77, 92, 105, 117 |
| Archive naming `ncp_<tag>_<os_label>_<arch>.<ext>` | stage steps |
| `release-publish.if` gates on push OR dispatch+publish | line 119 |
| `prerelease: true` auto-detect for `-rc.`/`-alpha.`/`-beta.` | line 156 |
| `fail_on_unmatched_files: true` + `if-no-files-found: error` | lines 134, 154 |
| `SHA256SUMS` as discrete release asset | lines 143-151 |
| Per-job `timeout-minutes` (25 build, 10 publish) | lines 60, 121 |

## Safeguards baked into release.yml

1. **`publish: false` default** — `workflow_dispatch` against an existing tag (e.g. dispatching on `v0.3.3` to test the workflow) produces workflow-run artifacts only. Does NOT touch the existing published Release.
2. **Explicit `ref:` on checkout** — without this, `workflow_dispatch` builds `main`'s HEAD instead of the requested tag, silently producing mislabeled artifacts.
3. **Strict tag-format archives** — naming includes the leading `v` to match git tags; matrix tuples explicit, no string-building drift.
4. **Brick WASM never rebuilt** — committed `.wasm` artifacts used verbatim (already digest-gated by `wasm-digest-check`).
5. **Apache 2.0 §4(d) compliance** — `LICENSE` + `NOTICE` packaged into every archive alongside `README.md`.
6. **Pre-release auto-detect** — `v*-rc.*` tags create `prerelease: true` GitHub Releases automatically; full versions stay `prerelease: false`.

## Verification (local, on Windows)

| Check | Result |
|---|---|
| Python YAML parse | ✅ `PARSED OK`, 2 triggers, 2 jobs, 3-entry matrix |
| Phase 3.0 inline-flow-mapping bug (`with: { key: ${{ … }} }`) | ✅ Not present — all `with:` blocks use block style |
| `cargo fmt --all -- --check` | ✅ |
| `cargo clippy -p ncp-runtime --all-targets --locked -- -D warnings` | ✅ |
| `cargo test -p ncp-runtime --all-targets --locked` | ✅ 44 unit + 5 smoke = 49 tests |

## Test plan

- [ ] DCO check ✅
- [ ] All 10 required checks pass (validate ×2, wasm-digest-check, DCO; Rust workflow: fmt, clippy, test ×3 OSes, wasm-build) — no Rust source touched
- [ ] `release.yml` does NOT appear in this PR's check rollup (release/dispatch-only triggers)
- [ ] After merge: dry-run `gh workflow run release.yml -f tag=v0.3.3 -f publish=false` produces 3 archive artifacts without modifying the existing v0.3.3 Release (verified in PUBLISHING.md §3, executed during release ceremony)

## Not in this PR (deferred)

| Item | Where |
|---|---|
| `Dockerfile` + `.github/workflows/docker.yml` | PR C |
| Filling the Docker placeholder in `docs/INSTALL.md` Option 2 | PR C |
| `docs/PUBLISHING.md` §7 (Docker tag publishing + GHCR cleanup) | PR C |
| `docs/PUBLISHING.md` §8 (`cargo publish` to crates.io) | PR D |
| `runtime/Cargo.toml` version bump 0.3.3 → 0.3.4 | PR D |
| Actual `v0.3.4` tag push + release ceremony | After PR D merges |

Part of Phase 3A.1 — see [docs/ROADMAP.md](docs/ROADMAP.md) §3.