### PR TITLE
Phase 3A.1 PR C: Docker image + GHCR publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,69 @@
+# .dockerignore
+# Excludes content not needed in the Docker build context for the ncp
+# runtime image. Reduces context size sent to the Docker daemon and
+# prevents accidental baking of unrelated artifacts into the image.
+
+# ── Cargo build artifacts (regenerated in the Dockerfile's builder stage)
+target/
+**/target/
+
+# ── Git
+.git/
+.gitignore
+.gitattributes
+
+# ── Node tooling (the TypeScript validator under tools/ncp-validate is
+#    unrelated to the runtime image build)
+tools/node_modules/
+tools/**/node_modules/
+
+# ── Non-runtime project content (not needed for either build OR the
+#    final image; verified: no include_str!/include_bytes! Rust references
+#    against these paths, Dockerfile doesn't COPY them, safe to exclude)
+.github/
+bench/
+docs/
+spec/
+schemas/
+conformance/
+
+# ── IDE / editor / OS junk
+.vscode/
+.idea/
+*.swp
+*.swo
+*.bak
+*.tmp
+.DS_Store
+Thumbs.db
+
+# ── Local secrets / credentials (defence-in-depth; should never be in repo
+#    in the first place, but we exclude here so a maintainer's accidentally-
+#    placed local credential file isn't sent to the Docker daemon)
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+*.p12
+*.pfx
+.ssh/
+id_rsa
+id_rsa.*
+.cargo/credentials
+.cargo/credentials.toml
+.npmrc
+
+# ── Local-only planning artifacts (gitignored at the repo level, but
+#    may exist on a maintainer's working tree and would otherwise be
+#    sent to the Docker daemon)
+NCP_IMPLEMENTATION_PLAN.md
+NCP_CONTEXT_BRIEF.md
+
+# ── Release-ceremony scratch files (used locally during release prep;
+#    never belong in the image)
+RELEASE_NOTES_*.md
+SHA256SUMS
+ncp_*.tar.gz
+ncp_*.zip
+ncp_*.sha256

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+#
+# DOCKER WORKFLOW INVARIANTS
+#   - Triggers: push to tags matching 'v*' OR workflow_dispatch with `tag`
+#     and `push` inputs.
+#   - workflow_dispatch defaults to push=false (builds image but does NOT
+#     push to GHCR). Set push=true to actually publish. Mirrors the
+#     `publish` safety in release.yml and prevents dispatched runs against
+#     existing tags from polluting the GHCR namespace.
+#   - `push` is a `type: choice` (string) input. The `push:` parameter on
+#     docker/build-push-action uses unambiguous `== 'true'` comparison
+#     (same rationale as release.yml's `publish` gate).
+#   - The "Resolve release tag" step validates the tag format AND outputs
+#     it explicitly so docker/metadata-action references the requested
+#     tag, NOT whatever github.ref happens to be. docker/metadata-action
+#     derives tags from GitHub event context by default — on
+#     workflow_dispatch from a branch, that would generate tags like
+#     `main` instead of the user-requested tag.
+#   - The tag-format regex enforces strict semver shape: `-` (NOT `.`)
+#     introduces any pre-release segment. `v0.3.4.rc.1` would otherwise
+#     pass a loose regex but break `type=semver` downstream.
+#   - actions/checkout MUST use the resolved tag (not inputs.tag directly)
+#     so the build sees the tagged source tree.
+#   - Strict-pin tags ONLY: each release publishes exactly TWO equivalent
+#     exact-version tags (e.g. `v0.3.4` AND `0.3.4`). `flavor: latest=false`
+#     disables docker/metadata-action's default auto-latest behavior;
+#     without that flag, an unwanted `:latest` tag would be generated.
+#     NEVER add `type=raw,value=latest` or `type=semver,pattern={{major}}.{{minor}}`.
+#   - Pre-release tags (v*-rc.*, v*-alpha.*, v*-beta.*) produce image tags
+#     like `v0.3.4-rc.1` AND `0.3.4-rc.1`. BOTH must be cleaned up if the
+#     RC is discarded (see docs/PUBLISHING.md section 6 RC cleanup).
+#   - Pushes to ghcr.io/madeinplutofabio/ncp (image namespace inherits
+#     repo visibility).
+#   - This workflow triggers only on push:tags + workflow_dispatch — never
+#     pull_request — so the job name is NOT bound by branch-protection
+#     ruleset.
+
+name: Docker
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v0.3.4 or v0.3.4-rc.1)'
+        required: true
+        type: string
+      push:
+        description: 'Push image to GHCR? (false = build only, do not publish)'
+        required: false
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+        default: 'false'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  docker-build-publish:
+    name: build & publish
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Resolve release tag
+        id: release-tag
+        shell: bash
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "::error::Docker release tag must look like v0.3.4 or v0.3.4-rc.1; got: $TAG"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release-tag.outputs.tag }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata (strict-pin tags only)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/madeinplutofabio/ncp
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ steps.release-tag.outputs.tag }}
+            type=semver,pattern={{version}},value=${{ steps.release-tag.outputs.tag }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push == 'true') }}
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1.7
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+#
+# Dockerfile for the NCP reference runtime (ncp CLI).
+#
+# Two stages:
+#   1. `build`   — full Rust 1.94 toolchain on Debian bookworm; produces a
+#                  static-friendly release binary of the `ncp` bin.
+#   2. final     — distroless Debian 12 with libc + libgcc_s (no shell, no
+#                  package manager, runs as non-root). Image is ~25 MB.
+#
+# Final image layout:
+#   /usr/local/bin/ncp        — the CLI (ENTRYPOINT)
+#   /app/examples/graphs/**   — runnable example graphs
+#   /app/examples/bricks/**   — committed WASM bricks (digest-gated by
+#                              validate.yml's wasm-digest-check)
+#   /app/LICENSE              — Apache 2.0 (compliance §4(d))
+#   /app/NOTICE               — project notice
+#
+# Usage (post-publish):
+#   docker run --rm ghcr.io/madeinplutofabio/ncp:v0.3.4 --version
+#   docker run --rm ghcr.io/madeinplutofabio/ncp:v0.3.4 run \
+#     examples/graphs/echo-pipeline/graph.yaml \
+#     --input examples/graphs/echo-pipeline/sample.json
+#
+# Note: WASM brick artifacts are NOT rebuilt during this image build —
+# the committed examples/bricks/**/*.wasm files are used verbatim (their
+# byte-for-byte source-rebuild fidelity is already gated by
+# validate.yml's wasm-digest-check on every PR/push to main).
+
+# ──────────────────────────────────────────────────────────────────────
+# Stage 1: build
+# ──────────────────────────────────────────────────────────────────────
+FROM rust:1.94-bookworm AS build
+
+WORKDIR /src
+
+# Copy the entire build context (filtered by .dockerignore — see that file
+# for what's excluded; runtime/, bricks/*, Cargo.toml, Cargo.lock,
+# rust-toolchain.toml, examples/, LICENSE, NOTICE are included).
+COPY . .
+
+# Build the release binary with --locked to ensure the published image
+# uses the exact dependency versions committed in Cargo.lock.
+RUN cargo build -p ncp-runtime --release --locked --bin ncp
+
+# ──────────────────────────────────────────────────────────────────────
+# Stage 2: final (distroless)
+# ──────────────────────────────────────────────────────────────────────
+FROM gcr.io/distroless/cc-debian12:nonroot
+
+# OCI image labels (rendered as image metadata; visible via `docker inspect`)
+LABEL org.opencontainers.image.title="ncp"
+LABEL org.opencontainers.image.description="NCP reference runtime — composable, auditable WASM agent graphs"
+LABEL org.opencontainers.image.source="https://github.com/madeinplutofabio/neural-computation-protocol"
+LABEL org.opencontainers.image.url="https://github.com/madeinplutofabio/neural-computation-protocol"
+LABEL org.opencontainers.image.documentation="https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/INSTALL.md"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.vendor="madeinpluto"
+
+WORKDIR /app
+
+# Binary at a standard CLI install location.
+COPY --from=build /src/target/release/ncp /usr/local/bin/ncp
+
+# Examples baked in so `docker run … ncp run examples/…` works without a
+# bind-mount. Relative paths resolve under WORKDIR=/app.
+COPY --from=build /src/examples /app/examples
+
+# Apache 2.0 §4(d): NOTICE must accompany redistributed binaries.
+COPY --from=build /src/LICENSE /app/LICENSE
+COPY --from=build /src/NOTICE /app/NOTICE
+
+# Distroless `:nonroot` runs as UID 65532 by default. Files copied via
+# COPY get root ownership but world-readable perms (644), so the nonroot
+# user can read them. No chown step needed.
+
+ENTRYPOINT ["/usr/local/bin/ncp"]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -60,14 +60,33 @@ Each archive contains the `ncp` binary, the `examples/` tree, plus `LICENSE`, `N
 
 ## Option 2 — Docker (Linux x86_64)
 
+Image base: `gcr.io/distroless/cc-debian12:nonroot` (small distroless runtime image; no shell, runs as non-root). The image bakes in `/app/examples/` (WORKDIR = `/app`) so example paths just work — no bind-mount needed.
+
 ```bash
+# Pull
 docker pull ghcr.io/madeinplutofabio/ncp:v0.3.4
+
+# Verify
 docker run --rm ghcr.io/madeinplutofabio/ncp:v0.3.4 --version
+
+# Run the quick-verify example (examples/ are inside the image)
+docker run --rm ghcr.io/madeinplutofabio/ncp:v0.3.4 \
+  run examples/graphs/echo-pipeline/graph.yaml \
+  --input examples/graphs/echo-pipeline/sample.json
 ```
 
-Image base is `gcr.io/distroless/cc-debian12:nonroot` (~25 MB). The image bakes in `/app/examples/` so you can run example graphs without mounting anything. See **Quick verify** below.
+To run your own graph, mount a host directory:
 
-Image tags are strict-pin only — there's no `:latest` and no floating `:0.3` tag. Always specify a full version.
+```bash
+docker run --rm -v "$PWD/my-graphs:/work:ro" -w /work \
+  ghcr.io/madeinplutofabio/ncp:v0.3.4 \
+  run my-graph.yaml --input my-input.json
+```
+
+**Tag conventions** (strict-pin only):
+- Each release publishes **two equivalent** exact-version tags: `v0.3.4` (matches the git tag) and `0.3.4` (semver-canonical). Same image digest.
+- **No `:latest`**, no floating `:0.3` or `:0` — always specify a full version.
+- Platform: **`linux/amd64` only** (Linux aarch64 / multi-arch deferred to [Phase 3C](ROADMAP.md#5-phase-3c--production-profile-hardening-track)).
 
 ---
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -9,13 +9,13 @@ End-to-end ceremony for cutting a new NCP version. This is the maintainer-facing
 companion to [`docs/INSTALL.md`](INSTALL.md) (which is adopter-facing).
 
 > **Phase 3A.1 build-out:** this doc is added incrementally across three PRs.
-> - **PR B (this PR)** — Sections 1–6: tag preparation, signed-tag creation,
+> - **PR B** — Sections 1–6: tag preparation, signed-tag creation,
 >   `Release` workflow ceremony, RC test-tag flow.
-> - **PR C** — Section 7: GHCR Docker image publish (added when the Docker
->   workflow lands).
+> - **PR C (this PR)** — Section 7: GHCR Docker image publish, plus the
+>   GHCR cleanup commands folded into Section 6's RC tear-down.
 > - **PR D** — Section 8: `cargo publish` to crates.io (added when the
 >   runtime crate version bumps to 0.3.4).
-> When all three PRs ship, this doc covers the full ceremony.
+> When PR D ships, this doc covers the full ceremony end-to-end.
 
 ---
 
@@ -26,6 +26,7 @@ companion to [`docs/INSTALL.md`](INSTALL.md) (which is adopter-facing).
 | GPG key configured for signed tags | `git config --get user.signingkey` returns a non-empty key ID. Verify the key still works: `echo test \| gpg --clearsign` should prompt for passphrase and produce a signed block. |
 | Push access to `main` + tag push permission | `gh auth status` shows the active account with `repo` scope. |
 | `gh` CLI authenticated | `gh auth status` clean. |
+| GHCR cleanup permission | `gh auth status` should show package scopes before RC cleanup runs `gh api -X DELETE` against GHCR. If missing, run `gh auth refresh -s read:packages -s delete:packages`. Without this, the §6 RC cleanup script will fail with `403` even if `repo` scope is present. |
 | Zenodo integration ON for the repo | Visit https://zenodo.org/account/settings/github/ — toggle for `madeinplutofabio/neural-computation-protocol` is **enabled**. |
 | Working tree clean on latest `main` | `git status -sb` shows `## main...origin/main` with no modifications. |
 
@@ -119,15 +120,44 @@ new RC (`v0.3.4-rc.2`), and re-verify.
 Once the RC verifies clean, delete the RC artifacts before cutting the real tag.
 Leaving an RC tag pullable indefinitely confuses adopters.
 
+> ⚠ **Before running the script below**, confirm your `gh` CLI has GHCR
+> package-delete permission. GHCR package-version deletion requires the
+> `delete:packages` scope (and `read:packages` to look up the version ID).
+> If the `gh api -X DELETE` step returns `403`, refresh the token first:
+> ```bash
+> gh auth refresh -s read:packages -s delete:packages
+> ```
+
 ```bash
 RC="v0.3.4-rc.1"
+
+# Delete the GitHub Release + remote+local git tag
 gh release delete "$RC" --yes
 git push origin --delete "$RC"
 git tag -d "$RC"
-```
 
-> **PR C will extend this section** with `gh api`-based GHCR Docker tag cleanup
-> (each release publishes two GHCR tags; both must be deleted on RC cleanup).
+# Delete BOTH GHCR image tags. docker.yml publishes the RC as `v0.3.4-rc.1`
+# AND `0.3.4-rc.1` (strict-pin: two equivalent forms per release). Leaving
+# either tag pullable indefinitely confuses adopters with a "ghost" RC.
+#
+# --paginate is REQUIRED — GitHub paginates the package-versions endpoint
+# (~30 per page). Without it, after enough releases the target tag may
+# silently fall to page 2+ and the lookup returns nothing, leaving a
+# stale GHCR tag on the registry.
+OWNER=madeinplutofabio
+RC_SEMVER="${RC#v}"   # v0.3.4-rc.1 -> 0.3.4-rc.1
+for ghcr_tag in "$RC" "$RC_SEMVER"; do
+  VERSION_ID=$(gh api --paginate "/users/$OWNER/packages/container/ncp/versions" \
+    --jq ".[] | select(.metadata.container.tags[]? == \"$ghcr_tag\") | .id" \
+    | head -n 1)
+  if [ -n "$VERSION_ID" ]; then
+    echo "Deleting GHCR tag $ghcr_tag (version id $VERSION_ID)"
+    gh api -X DELETE "/users/$OWNER/packages/container/ncp/versions/$VERSION_ID"
+  else
+    echo "GHCR tag $ghcr_tag not found (already cleaned up or never created?)"
+  fi
+done
+```
 
 Then push the real tag:
 
@@ -157,10 +187,91 @@ Section 1's Prerequisites table) — the webhook may have been disabled.
 
 ---
 
-## Sections coming in PR C / PR D
+## 7. GHCR Docker image (auto-published by docker.yml)
 
-- **§7 — GHCR Docker image** (PR C) — `docker.yml` workflow + image tag cleanup.
-- **§8 — `cargo publish` to crates.io** (PR D) — pre-flight `cargo publish --dry-run`, manual publish command, README link audit on crates.io render.
+The `Docker` workflow (`.github/workflows/docker.yml`) fires on the same
+`v*` tag push that triggers the Release workflow. Both run concurrently
+on a single tag push — no separate operator action required.
 
-When all three PRs ship, this doc is the single canonical reference for the
-full release ceremony.
+Each release publishes **two equivalent strict-pin tags** to GHCR:
+- `ghcr.io/madeinplutofabio/ncp:v0.3.4` (matches the git tag verbatim)
+- `ghcr.io/madeinplutofabio/ncp:0.3.4` (semver-canonical form)
+
+Same image digest, two reference forms. No `:latest`, no floating `:0.3`.
+
+### 7.1 Optional: dispatch build-only dry-run for an existing tag
+
+The Docker workflow accepts a `workflow_dispatch` input with `push: false`
+(default) so you can build the image without pushing it to GHCR — useful
+for diagnosing Dockerfile/image-build issues without pushing or mutating
+GHCR. Note: the dispatch checks out the resolved tag, so this only works
+for tags that **already exist** in the repo (re-validating an existing
+tag's build, not pre-tag-push testing).
+
+```bash
+gh workflow run docker.yml \
+  -f tag=v0.3.4 \
+  -f push=false
+```
+
+The image gets built on the runner, build cache populates, but the
+`docker push` step is skipped. Inspect the workflow logs for any build
+errors. Set `push=true` to actually publish.
+
+### 7.2 Post-publish verification
+
+After a real tag push (or after a dispatch with `push=true`):
+
+```bash
+# Pull both tag forms — should resolve to the same image digest
+docker pull ghcr.io/madeinplutofabio/ncp:v0.3.4
+docker pull ghcr.io/madeinplutofabio/ncp:0.3.4
+
+# Confirm both refer to the same image (digest equality)
+docker image inspect --format '{{.Id}}' ghcr.io/madeinplutofabio/ncp:v0.3.4
+docker image inspect --format '{{.Id}}' ghcr.io/madeinplutofabio/ncp:0.3.4
+
+# Functional verify (mirrors docs/INSTALL.md quick-verify)
+docker run --rm ghcr.io/madeinplutofabio/ncp:v0.3.4 --version
+docker run --rm ghcr.io/madeinplutofabio/ncp:v0.3.4 \
+  run examples/graphs/echo-pipeline/graph.yaml \
+  --input examples/graphs/echo-pipeline/sample.json
+```
+
+### 7.3 First-publish: GHCR package visibility (ONE-TIME setup)
+
+The first push to a previously-non-existent GHCR namespace creates the
+package as **private** by default. Adopters won't be able to `docker
+pull` until visibility is flipped to public.
+
+After the first successful `v*` tag push that runs docker.yml:
+
+1. Visit https://github.com/madeinplutofabio?tab=packages and click the
+   `ncp` container package.
+2. Click **Package settings** (right sidebar).
+3. Scroll to **Danger Zone → Change visibility → Public**.
+4. Confirm by typing the package name.
+
+Subsequent releases inherit the current visibility — this is a one-time
+step. Verify the package is actually publicly pullable (the behavioral
+test, not a registry-protocol probe — OCI registries can challenge
+even public images with 401+WWW-Authenticate as part of normal auth
+handshake, so HTTP status alone isn't a reliable visibility signal):
+
+```bash
+# Make sure no cached GHCR credentials are in play
+docker logout ghcr.io 2>/dev/null || true
+
+# Anonymous pull — succeeds for public, fails with "denied" for private
+docker pull ghcr.io/madeinplutofabio/ncp:v0.3.4
+```
+
+---
+
+## Section coming in PR D
+
+- **§8 — `cargo publish` to crates.io** (PR D) — pre-flight
+  `cargo publish --dry-run`, manual publish command, README link audit
+  on crates.io render.
+
+When PR D ships, this doc covers the full release ceremony end-to-end.


### PR DESCRIPTION
## Summary

- Third install path for NCP: distroless Docker image published to `ghcr.io/madeinplutofabio/ncp` on every `v*` tag push. Pairs with the GitHub Release archives (PR B) and the in-progress `cargo publish` path (PR D).
- Strict-pin tags only — each release publishes BOTH `v0.3.4` (git-tag form) AND `0.3.4` (semver form), same image digest. No `:latest`, no floating `:0.3`.
- Multi-stage build: `rust:1.94-bookworm` builder → `gcr.io/distroless/cc-debian12:nonroot` final (~25 MB). Examples baked under `WORKDIR=/app` so `docker run … ncp run examples/…` works with no bind-mount.

## Files

| File | Change |
|---|---|
| `Dockerfile` | new — two-stage build, distroless final image, ships LICENSE + NOTICE per Apache 2.0 §4(d) |
| `.dockerignore` | new — excludes `target/`, `.git/`, `docs/`, `spec/`, `schemas/`, `conformance/`, IDE junk, secrets, local-only planning artifacts. Verified zero `include_str!`/`include_bytes!` references against any excluded path in the runtime crate. |
| `.github/workflows/docker.yml` | new — triggers on `push: tags: ['v*']` + `workflow_dispatch`. Dispatch defaults to `push=false` (build-only, no GHCR mutation) — same safety pattern as `release.yml`'s `publish` gate. |
| `docs/INSTALL.md` | Option 2 (Docker) filled in: pull/run/verify commands, bind-mount example, tag conventions block. |
| `docs/PUBLISHING.md` | New §7 (GHCR publish flow: build-only dry-run, post-publish digest-equality + functional verify, ONE-TIME first-publish visibility flip via behavioral anonymous-pull test). Extended §6 RC cleanup to delete BOTH GHCR tag forms via `gh api --paginate`. Added Prerequisites row + inline ⚠ warning callout for `read:packages` + `delete:packages` scopes. |

## Invariants enforced by the workflow

- `flavor: latest=false` on `docker/metadata-action@v5` — disables the default auto-`:latest` tag.
- Tag-format regex enforces strict semver shape: prerelease segments must start with `-` (not `.`); `v0.3.4.rc.1` is rejected at workflow startup.
- Explicit "Resolve release tag" step + explicit `value=` on `type=raw`/`type=semver` — without this, `workflow_dispatch` from a branch generates `main`-derived tags via `metadata-action`'s default `github.ref` resolution.
- `actions/checkout@v4` uses the resolved tag, not `inputs.tag` directly — guarantees the build sees the tagged source tree.
- `push:` parameter on `docker/build-push-action@v5` uses unambiguous `== 'true'` comparison against the `type: choice` input (same rationale as `release.yml`'s `publish` gate).
- `concurrency.cancel-in-progress: false` — never cancel an in-flight release publish.

## Verification

- **Local `docker build` not run** — no Docker daemon on the Windows dev box. Will verify end-to-end at the `v0.3.4-rc.1` release ceremony (PR D + tag-push), which exercises both `release.yml` and `docker.yml` against the same tag.
- **PR-time CI:** the existing 10 required checks (DCO, validate ×2, wasm-digest-check, fmt, clippy, test ×3 OSes, wasm-build). `docker.yml` does NOT run on `pull_request` — by design, never appears in this PR's check rollup and isn't bound by the required-checks ruleset.

## Deferred to Phase 3C

- `linux/arm64` multi-arch image (current workflow is `platforms: linux/amd64` only).

## Test plan

- [ ] PR-time: all 10 required checks pass.
- [ ] Post-merge, ceremony: `v0.3.4-rc.1` tag push fires both `release.yml` and `docker.yml`; GHCR publishes both `v0.3.4-rc.1` and `0.3.4-rc.1`, same digest.
- [ ] `docker pull ghcr.io/madeinplutofabio/ncp:v0.3.4-rc.1` succeeds anonymously after ONE-TIME visibility flip (§7.3).
- [ ] `docker run --rm <image> --version` prints `0.3.4`.
- [ ] `docker run --rm <image> run examples/graphs/echo-pipeline/graph.yaml --input examples/graphs/echo-pipeline/sample.json` exits 0 with deterministic echo output.
- [ ] §6 RC cleanup deletes BOTH GHCR tag forms (no ghost RC remains pullable).