### PR TITLE
chore(release): prepare v0.3.4 crates.io publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the NCP specification and its reference tooling
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Brick versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). NCP protocol versions follow the versioning policy in the spec (v0.2.x patch-compatible, breaking changes require v0.3.0).
 
-## [0.3.4] — 2026-MM-DD
+## [0.3.4] — 2026-05-26
 
 ### Added
 - **`docs/INSTALL.md`**: install matrix for adopters — GitHub Releases archives,
@@ -32,6 +32,34 @@ Brick versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - **`README.md`**: top-level "Install" section above "Quick start", linking
   to `docs/INSTALL.md`. Pre-built install paths are now the default story;
   building from source is positioned as the developer path
+- **Release workflow** (`.github/workflows/release.yml`): pushing a `v*` tag
+  produces a GitHub Release with per-OS archives (`linux_x86_64.tar.gz`,
+  `macos_aarch64.tar.gz`, `windows_x86_64.zip`) plus `SHA256SUMS`. Each
+  archive ships the `ncp` binary, `examples/`, `LICENSE`, `NOTICE`,
+  `README.md` (Apache 2.0 §4(d) compliant). `workflow_dispatch` accepts a
+  `tag` input and a `publish` choice (default `false`) for build-only
+  dry-runs against existing tags. Pre-release tags (`v*-rc.*`, `v*-alpha.*`,
+  `v*-beta.*`) auto-marked as GitHub prerelease
+- **`docs/PUBLISHING.md`**: maintainer-facing release ceremony covering
+  prerequisites, release-state confirmation, workflow dry-run, RC tag flow,
+  artifact verification, RC cleanup (including BOTH GHCR tag forms via
+  `gh api --paginate`), Zenodo auto-archive verification, GHCR publish flow
+  (build-only dry-run, post-publish digest-equality verification, ONE-TIME
+  first-publish visibility flip), and crates.io publish flow (early
+  dry-run gate, live publish from the resolved tag, README link audit,
+  clean-host install verification)
+- **Docker image** (`Dockerfile` + `.dockerignore` + `.github/workflows/docker.yml`):
+  two-stage build (`rust:1.94-bookworm` → `gcr.io/distroless/cc-debian12:nonroot`,
+  small distroless final image). Examples baked under `WORKDIR=/app`. Triggers
+  on `v*` tag push + `workflow_dispatch`. Each release publishes BOTH `v0.3.4`
+  (git-tag form) AND `0.3.4` (semver form) to GHCR — same image digest, two
+  equivalent references. No `:latest`, no floating `:0.3`. `linux/amd64`
+  only (multi-arch deferred to Phase 3C)
+
+### Changed
+- **`runtime/Cargo.toml`**: crate version bumped `0.3.3` → `0.3.4` to align
+  with the v0.3.4 release tag. `Cargo.lock` updated to match (only the
+  `ncp-runtime` self-version entry; no transitive dep drift)
 
 ## [0.3.3] — 2026-05-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.33.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "ncp-runtime"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #   1. `build`   — full Rust 1.94 toolchain on Debian bookworm; produces a
 #                  static-friendly release binary of the `ncp` bin.
 #   2. final     — distroless Debian 12 with libc + libgcc_s (no shell, no
-#                  package manager, runs as non-root). Image is ~25 MB.
+#                  package manager, runs as non-root). Small distroless final image.
 #
 # Final image layout:
 #   /usr/local/bin/ncp        — the CLI (ENTRYPOINT)

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -8,14 +8,11 @@
 End-to-end ceremony for cutting a new NCP version. This is the maintainer-facing
 companion to [`docs/INSTALL.md`](INSTALL.md) (which is adopter-facing).
 
-> **Phase 3A.1 build-out:** this doc is added incrementally across three PRs.
-> - **PR B** — Sections 1–6: tag preparation, signed-tag creation,
->   `Release` workflow ceremony, RC test-tag flow.
-> - **PR C (this PR)** — Section 7: GHCR Docker image publish, plus the
->   GHCR cleanup commands folded into Section 6's RC tear-down.
-> - **PR D** — Section 8: `cargo publish` to crates.io (added when the
->   runtime crate version bumps to 0.3.4).
-> When PR D ships, this doc covers the full ceremony end-to-end.
+> This doc covers the full release ceremony end-to-end: tag preparation,
+> signed-tag creation, RC test-tag flow, GitHub Release artifacts via the
+> `Release` workflow, GHCR Docker image publish via the `Docker` workflow,
+> and `cargo publish` to crates.io. Built out incrementally across PRs B–D
+> of Phase 3A.1.
 
 ---
 
@@ -67,6 +64,43 @@ When complete, all 3 archive artifacts should be downloadable from the Actions
 run page. Verify the `v0.3.3` GitHub Release page is **unchanged** (no new
 assets). If `publish=false` ever produces assets on the existing Release, that's
 a workflow bug — file an issue.
+
+## 3.1 crates.io publish dry-run (pre-flight gate)
+
+Run this **before tagging** so any crates.io-side blocker (name squat,
+expired token, README-render regression, `categories` allowlist drift,
+`include` array dropping `LICENSE`/`NOTICE`) surfaces while it can still
+be fixed by a tiny follow-up PR — not after `v0.3.4` is tagged and the
+version is already burned.
+
+Run from `main` HEAD (post-PR-D-merge — `runtime/Cargo.toml` already
+shows the upcoming version):
+
+```bash
+# 1. File-listing gate — proves LICENSE + NOTICE + README ship in the
+#    .crate (Apache 2.0 §4(d) compliance + crates.io render). Mirrors
+#    PR A's hard gate.
+cargo package -p ncp-runtime --list > /tmp/ncp-runtime-package-files.txt
+grep -Fx README.md /tmp/ncp-runtime-package-files.txt
+grep -Fx LICENSE /tmp/ncp-runtime-package-files.txt
+grep -Fx NOTICE /tmp/ncp-runtime-package-files.txt
+# Expected: all three commands exit 0.
+
+# 2. Live dry-run against crates.io's validation API. Catches name
+#    squat, expired token, allowlist drift, oversized .crate (10 MB
+#    limit), and packaging metadata regressions.
+cargo publish -p ncp-runtime --dry-run --locked
+```
+
+Both must exit 0 cleanly.
+
+**If the dry-run fails after PR D has merged:** the upcoming version is
+now "tainted" — `runtime/Cargo.toml` claims the version but you can't
+actually publish it. Recovery is a tiny follow-up PR that lands the fix
+on top of the existing version (if the fix is metadata-only and the
+version hasn't been tagged yet), OR bump to the next patch (e.g.
+`0.3.4` → `0.3.5`) if the version slot is unrecoverable. **Either way,
+do not push the release tag until §3.1 is green.**
 
 ## 4. Push a pre-release tag (RC)
 
@@ -268,10 +302,68 @@ docker pull ghcr.io/madeinplutofabio/ncp:v0.3.4
 
 ---
 
-## Section coming in PR D
+## 8. `cargo publish` to crates.io
 
-- **§8 — `cargo publish` to crates.io** (PR D) — pre-flight
-  `cargo publish --dry-run`, manual publish command, README link audit
-  on crates.io render.
+Final irreversible step. Runs after the GitHub Release + GHCR image are
+verified clean (§5–§7). The pre-flight gate in §3.1 already established
+that the publish payload is valid — §8 is the live `cargo publish`.
 
-When PR D ships, this doc covers the full release ceremony end-to-end.
+**Publish from the resolved tag**, not from `main` HEAD. Even one
+commit's drift between tag push and `cargo publish` would ship code on
+crates.io that doesn't match the v-tag's GitHub Release tarball or its
+GHCR image digest:
+
+```bash
+git fetch --tags origin
+git checkout v0.3.4
+cargo publish -p ncp-runtime --locked
+```
+
+`--locked` is correct here — the tag checkout is clean (not "dirty"),
+and `--locked` guarantees `cargo publish` resolves dependencies against
+the exact `Cargo.lock` committed for the release. Do NOT pass
+`--allow-dirty` from a tag checkout; if cargo complains about a dirty
+tree, something is wrong (untracked files, stray edits) — investigate
+before publishing.
+
+### 8.1 Post-publish verification
+
+Clean-host install proves an end-user `cargo install` works against the
+freshly-published crate. Run on a host with no NCP source checkout
+(e.g. a throwaway Docker container):
+
+```bash
+cargo install ncp-runtime --version 0.3.4 --locked
+ncp --version
+# Expected: prints "0.3.4"
+```
+
+Or from a clean Docker container (mirrors the environment most adopters
+will hit):
+
+```bash
+docker run --rm rust:1.94-bookworm bash -c \
+  "cargo install ncp-runtime --version 0.3.4 --locked && ncp --version"
+```
+
+### 8.2 README link audit on crates.io
+
+crates.io renders the `runtime/Cargo.toml`-declared README (`../README.md`)
+as the crate's landing-page docs. Relative links that work on GitHub
+(e.g. `docs/ADOPTION_GUIDE.md`) may 404 on the crates.io renderer
+because there is no `docs/` directory inside the `.crate` package.
+
+1. Open https://crates.io/crates/ncp-runtime/0.3.4
+2. Scroll through the rendered README.
+3. Click every link.
+4. If any 404: ship a tiny follow-up PR converting the broken relative
+   links to absolute `https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/…`
+   URLs. Not a 3A.1 blocker (cosmetic), but the follow-up should land
+   within 1–2 days of publish to avoid lingering broken links.
+
+### 8.3 Scope
+
+This phase publishes **`ncp-runtime` only**. Brick crates
+(`ncp-echo`, `ncp-classifier-stub`) are `cdylib`s targeting
+`wasm32-unknown-unknown` and not useful as host-target deps; they're
+deferred to Phase 3A.4 (SDKs) when the brick-author workflow lands.

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ncp-runtime"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

- Closes out Phase 3A.1 Distribution. Bumps `ncp-runtime` to `0.3.4`, completes `docs/PUBLISHING.md` with the crates.io publish flow (early dry-run gate + live publish from the resolved tag), and folds in a couple of correctness fixes that surfaced during the dry-run.
- After this lands the queue is just the release ceremony itself (`v0.3.4-rc.1` → verify → cleanup → `v0.3.4` → `cargo publish`), not more code/doc PRs.
- Pre-flight `cargo publish --dry-run --locked` runs warning-free against crates.io's validation API; all 21 packaged files (including `LICENSE`, `NOTICE`, `README.md`) verified present in the `.crate`.

## Files

| File | Change |
|---|---|
| `runtime/Cargo.toml` | `version = "0.3.3"` → `"0.3.4"` |
| `Cargo.lock` | Two single-line entries: (1) `ncp-runtime` self-version `0.3.3` → `0.3.4`. (2) `gimli` `0.33.1` → `0.33.0` via `cargo update -p gimli` — `0.33.1` was yanked upstream and surfaced as a warning on every `cargo install ncp-runtime` and on the publish dry-run. Tight transitive downgrade (zero other crates affected; `gimli` is a DWARF debuginfo crate, not behavior-facing). Re-verified via `cargo check`/`cargo test`/`cargo publish --dry-run` all green and warning-free. |
| `Dockerfile` | Dropped unverified `~25 MB` image-size claim from the header comment. Same correction as the CHANGELOG removal — avoids leaving an unsupported claim in the repo after agreeing not to make it until measured. |
| `CHANGELOG.md` | Filled the v0.3.4 date placeholder (`2026-MM-DD` → `2026-05-26`); folded in PR B + PR C + PR D bullets that landed since v0.3.3; new `### Changed` section for the version bump (mirrors v0.3.3 entry's pattern). |
| `docs/PUBLISHING.md` | Replaced "section coming in PR X" build-out preamble with steady-state intro. NEW §3.1 — crates.io publish dry-run as a pre-flight gate before any tag push (catches name squat, expired token, README-render regression, `categories` allowlist drift, `include` array dropping `LICENSE`/`NOTICE`; uses three `grep -Fx` invocations so missing files actually fail the gate rather than silently slipping past an OR-match regex). NEW §8 — live `cargo publish` from the resolved tag checkout, post-publish clean-host install verification, crates.io README link audit, scope note that brick crates remain unpublished this phase. |

## Pre-flight verification (run locally before commit)

```text
$ cargo package -p ncp-runtime --list --allow-dirty
.cargo_vcs_info.json
Cargo.lock
Cargo.toml
Cargo.toml.orig
LICENSE
NOTICE
README.md
src/*.rs  (×11)
src/bin/ncp-bench.rs
tests/smoke.rs

$ grep -Fx LICENSE / NOTICE / README.md   → all three exit 0

$ cargo publish -p ncp-runtime --dry-run --locked
Packaged 21 files, 210.5KiB (52.2KiB compressed)
Verifying ncp-runtime v0.3.4
Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.35s
warning: aborting upload due to dry run
(no other warnings — yank warning gone after gimli fix)

$ cargo test -p ncp-runtime --locked
test result: ok. 5 passed; 0 failed
```

## Why the early §3.1 dry-run gate (and not just §8)

crates.io is the one irreversible/manual distribution channel. If the package fails because of packaging metadata, included files, README rendering, license fields, or relative links, you want to know **before** pushing RC/final tags and spending time verifying GitHub Release + GHCR artifacts. §3.1 runs from `main` HEAD post-merge — sequenced as a gate that catches drift between PR A's merge-time dry-run and ceremony time. §8 remains the live publish, deliberately last.

## Scope

This phase publishes `ncp-runtime` only. Brick crates (`ncp-echo`, `ncp-classifier-stub`) are `cdylib`s targeting `wasm32-unknown-unknown` and not useful as host-target deps; deferred to Phase 3A.4 (SDKs) when the brick-author workflow lands.

## Test plan

- [ ] PR-time: all 10 required checks pass.
- [ ] Post-merge, §3.1 ceremony gate: re-run `cargo package -p ncp-runtime --list | grep -Fx ...` (without `--allow-dirty`) + `cargo publish -p ncp-runtime --dry-run --locked` from clean `main` HEAD; both exit 0 cleanly.
- [ ] Ceremony: `v0.3.4-rc.1` signed tag → verify Release + GHCR artifacts.
- [ ] Ceremony: BOTH-form GHCR cleanup of RC tags (per §6).
- [ ] Ceremony: `v0.3.4` signed tag → verify Release + GHCR + Zenodo archive under concept DOI.
- [ ] Ceremony: `git checkout v0.3.4` → `cargo publish -p ncp-runtime --locked` (live).
- [ ] Ceremony: `cargo install ncp-runtime --version 0.3.4 --locked` from clean Docker container → `ncp --version` prints `0.3.4`.
- [ ] Ceremony: crates.io README link audit; follow-up PR if any 404.