### PR TITLE
fix(crates-io): repair README links and category metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,46 @@ All notable changes to the NCP specification and its reference tooling
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Brick versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). NCP protocol versions follow the versioning policy in the spec (v0.2.x patch-compatible, breaking changes require v0.3.0).
 
+## [0.3.5] — 2026-05-27
+
+### Fixed
+- **`README.md`**: converted repo-relative Markdown links and the
+  `NCP-logo.png` image src to absolute `https://github.com/.../blob/main/...`
+  (and `/raw/main/` for the image) URLs. crates.io renders the README as
+  the crate's landing-page docs, and resolves relative links from the
+  *crate's* manifest location (`runtime/`) — not the workspace root.
+  That made every relative link 404 on the v0.3.4 crates.io page (e.g.
+  `docs/INSTALL.md` became `runtime/docs/INSTALL.md`). Absolute URLs
+  render correctly on both crates.io and GitHub. Same-page anchors like
+  `#quick-start-runtime` are intentionally left relative.
+
+### Changed
+- **`runtime/Cargo.toml`** categories: replaced the misleading
+  `asynchronous` (the runtime is synchronous; wasmtime used in blocking
+  mode, no `tokio`/`futures`/`async fn`) with the accepted
+  `artificial-intelligence` category (crates.io's official scope:
+  "machine learning, deep learning, large language models, AI agents,
+  and related tooling" — direct fit for an agent-graph runtime).
+  Final categories: `["artificial-intelligence", "wasm",
+  "command-line-utilities"]`. Validated against the crates.io
+  allowlist via `cargo publish --dry-run --locked --allow-dirty`
+- **`runtime/Cargo.toml`**: crate version bumped `0.3.4` → `0.3.5`.
+  `Cargo.lock` updated to match (only the `ncp-runtime` self-version
+  entry; no transitive dep drift)
+- **`docs/PUBLISHING.md`** §3.1: added a README-content gate to the
+  pre-flight checklist. Unpacks the just-built `.crate` and greps for
+  any bare repo-relative Markdown links or HTML `src=` references that
+  crates.io would rewrite under the crate's subdirectory. Fail-hard
+  with non-zero exit. Catches the exact failure class that bit v0.3.4
+  (where the local dry-run was green but the rendered crates.io README
+  shipped with broken links). Version-derived so the gate doesn't need
+  hand-editing on every release
+- **`README.md`**: Docker quick-install example version pin bumped
+  `v0.3.4` → `v0.3.5` so the rendered crates.io README ships consistent
+  with the released image tag (intentionally not sweeping the equivalent
+  references in `docs/INSTALL.md` — those are deferred to a separate
+  doc-refresh PR post-v0.3.5)
+
 ## [0.3.4] — 2026-05-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "ncp-runtime"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 -->
 
 <p align="center">
-  <img src="NCP-logo.png" alt="NCP Logo" width="200" />
+  <img src="https://github.com/madeinplutofabio/neural-computation-protocol/raw/main/NCP-logo.png" alt="NCP Logo" width="200" />
 </p>
 
 <h1 align="center">NCP — Neural Computation Protocol</h1>
@@ -20,7 +20,7 @@
 
 ---
 
-**Docs:** [Adoption guide](docs/ADOPTION_GUIDE.md) · [Benchmarks](BENCHMARK.md) · [Cost model](COST_MODEL.md) · [Roadmap](docs/ROADMAP.md) · [Spec](spec/ncp-v0.2.3.md) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md)
+**Docs:** [Adoption guide](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/ADOPTION_GUIDE.md) · [Benchmarks](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/BENCHMARK.md) · [Cost model](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/COST_MODEL.md) · [Roadmap](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/ROADMAP.md) · [Spec](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/spec/ncp-v0.2.3.md) · [Contributing](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/CONTRIBUTING.md) · [Security](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/SECURITY.md)
 
 **Status:** Protocol v0.2.3 + validator are stable. The Phase 2 runtime is a reference implementation (fast, deterministic, benchmarked). Phase 3 focuses on integrations (MCP/LangGraph) and distribution.
 
@@ -73,7 +73,7 @@ If you ship “agentic” workflows in production and your **latency or LLM bill
 
 ## Benchmarks
 
-Benchmarks are in [`BENCHMARK.md`](BENCHMARK.md) with full methodology, raw JSON, and reproduction commands.
+Benchmarks are in [`BENCHMARK.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/BENCHMARK.md) with full methodology, raw JSON, and reproduction commands.
 
 **In practice:** if you can keep ~90% of requests off the LLM, your average latency and cost drop ~10×. The benchmark suite proves this curve end-to-end (mixed datasets + simulated 200ms LLM).
 
@@ -106,16 +106,16 @@ We measure a synthetic mixed workload where an LLM call costs **200ms** (simulat
 
 These results are measured end-to-end by cycling a dataset (`--dataset`) so the latency distribution includes both fast-path and slow-path requests in one run.
 
-**Cost follows the same curve**: if you avoid LLM calls, you avoid LLM spend. See [`COST_MODEL.md`](COST_MODEL.md).
+**Cost follows the same curve**: if you avoid LLM calls, you avoid LLM spend. See [`COST_MODEL.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/COST_MODEL.md).
 
 ---
 
 ## Install
 
-Three ways to get a working `ncp` CLI — full matrix (per-OS commands, checksums, architecture coverage) in [`docs/INSTALL.md`](docs/INSTALL.md):
+Three ways to get a working `ncp` CLI — full matrix (per-OS commands, checksums, architecture coverage) in [`docs/INSTALL.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/INSTALL.md):
 
 - **Download** a release archive: https://github.com/madeinplutofabio/neural-computation-protocol/releases/latest
-- **Docker** (Linux x86_64): `docker run --rm ghcr.io/madeinplutofabio/ncp:v0.3.4 --version`
+- **Docker** (Linux x86_64): `docker run --rm ghcr.io/madeinplutofabio/ncp:v0.3.5 --version`
 - **`cargo install`** (any platform with Rust 1.94+): `cargo install ncp-runtime --bin ncp --locked`
 
 For developers building from source, see [Quick start](#quick-start-runtime) below.
@@ -206,7 +206,7 @@ docs/            Roadmap and design notes
 
 ## Roadmap
 
-High-level roadmap lives in [`docs/ROADMAP.md`](docs/ROADMAP.md).
+High-level roadmap lives in [`docs/ROADMAP.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/ROADMAP.md).
 
 If you’re evaluating NCP today:
 - Phase 1 (Spec + Validator): ✅ complete

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -69,17 +69,18 @@ a workflow bug — file an issue.
 
 Run this **before tagging** so any crates.io-side blocker (name squat,
 expired token, README-render regression, `categories` allowlist drift,
-`include` array dropping `LICENSE`/`NOTICE`) surfaces while it can still
-be fixed by a tiny follow-up PR — not after `v0.3.4` is tagged and the
-version is already burned.
+`include` array dropping `LICENSE`/`NOTICE`, or repo-relative Markdown
+links that would 404 on the rendered crates.io page) surfaces while it
+can still be fixed by a tiny follow-up PR — not after the release tag
+is pushed and the version is already burned.
 
-Run from `main` HEAD (post-PR-D-merge — `runtime/Cargo.toml` already
-shows the upcoming version):
+Run from `main` HEAD with the upcoming version already in
+`runtime/Cargo.toml` (version-bump PR merged):
 
 ```bash
 # 1. File-listing gate — proves LICENSE + NOTICE + README ship in the
 #    .crate (Apache 2.0 §4(d) compliance + crates.io render). Mirrors
-#    PR A's hard gate.
+#    the original PR A hard gate.
 cargo package -p ncp-runtime --list > /tmp/ncp-runtime-package-files.txt
 grep -Fx README.md /tmp/ncp-runtime-package-files.txt
 grep -Fx LICENSE /tmp/ncp-runtime-package-files.txt
@@ -90,15 +91,48 @@ grep -Fx NOTICE /tmp/ncp-runtime-package-files.txt
 #    squat, expired token, allowlist drift, oversized .crate (10 MB
 #    limit), and packaging metadata regressions.
 cargo publish -p ncp-runtime --dry-run --locked
+
+# 3. README-content gate — proves the README inside the .crate does not
+#    contain repo-relative links that crates.io will rewrite under
+#    runtime/. Catches the v0.3.4-class regression where the local
+#    dry-run was green but the rendered crates.io README shipped with
+#    broken links.
+VERSION=$(grep '^version' runtime/Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')
+CRATE="target/package/ncp-runtime-${VERSION}.crate"
+CHECK_DIR="/tmp/ncp-crate-render-check"
+
+cargo package -p ncp-runtime --locked
+
+rm -rf "$CHECK_DIR"
+mkdir -p "$CHECK_DIR"
+tar xzf "$CRATE" -C "$CHECK_DIR"
+
+README="$CHECK_DIR/ncp-runtime-${VERSION}/README.md"
+
+# Markdown links that must be absolute GitHub URLs in the published README.
+# The (\./)? prefix catches both bare relative (docs/...) and dot-prefixed
+# relative (./docs/...) forms, so future link drift can't slip past.
+if grep -nE '\]\((\./)?(docs/|spec/|BENCHMARK\.md|COST_MODEL\.md|CONTRIBUTING\.md|SECURITY\.md|LICENSE|NOTICE)' "$README"; then
+  echo "ERROR: published README still contains bare repo-relative Markdown links"
+  exit 1
+fi
+
+# HTML image/link sources that must not remain repo-relative.
+if grep -nE 'src="(NCP-logo\.png|docs/|spec/)' "$README"; then
+  echo "ERROR: published README still contains bare repo-relative HTML src links"
+  exit 1
+fi
+
+echo "README link gate passed: no bare repo-relative links found in published README"
 ```
 
-Both must exit 0 cleanly.
+All three gates must exit 0 cleanly.
 
-**If the dry-run fails after PR D has merged:** the upcoming version is
-now "tainted" — `runtime/Cargo.toml` claims the version but you can't
-actually publish it. Recovery is a tiny follow-up PR that lands the fix
-on top of the existing version (if the fix is metadata-only and the
-version hasn't been tagged yet), OR bump to the next patch (e.g.
+**If any gate fails after the version-bump PR has merged:** the upcoming
+version is now "tainted" — `runtime/Cargo.toml` claims the version but
+you can't actually publish it. Recovery is a tiny follow-up PR that lands
+the fix on top of the existing version (if the fix is metadata-only and
+the version hasn't been tagged yet), OR bump to the next patch (e.g.
 `0.3.4` → `0.3.5`) if the version slot is unrecoverable. **Either way,
 do not push the release tag until §3.1 is green.**
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ncp-runtime"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -10,7 +10,7 @@ repository = "https://github.com/madeinplutofabio/neural-computation-protocol"
 homepage = "https://github.com/madeinplutofabio/neural-computation-protocol"
 readme = "../README.md"
 keywords = ["wasm", "agentic-ai", "graph", "deterministic", "ncp"]
-categories = ["wasm", "command-line-utilities", "asynchronous"]
+categories = ["artificial-intelligence", "wasm", "command-line-utilities"]
 include = [
     "src/**",
     "tests/**",


### PR DESCRIPTION
## Summary

Hotfix release for v0.3.4's crates.io page. Fixes both the **artifact bug** (broken README links + misleading `asynchronous` category) AND the **process bug** (pre-flight dry-run did not inspect the README as it appears inside the `.crate`).

- **Ships in v0.3.5**, not v0.3.4 — `cargo publish` ships immutable `.crate` files, so v0.3.4's broken page is permanent. v0.3.5 becomes "Latest" on crates.io once published.
- README link conversion + category swap are the symptom fix.
- New §3.1 README-content gate prevents the same failure class from shipping again.

## Why v0.3.5 right after v0.3.4

v0.3.4 shipped to crates.io with two issues that only surface in the rendered registry page:

1. **Every relative Markdown link 404'd** because crates.io resolves relative links from the *crate's* manifest location (`runtime/`), not the workspace root. `docs/INSTALL.md` got rewritten to `runtime/docs/INSTALL.md` which doesn't exist. The local `cargo publish --dry-run --locked` was green but the rendered page was broken.
2. **`categories` listed `asynchronous`** which is wrong — the runtime is synchronous (wasmtime in blocking mode, no `tokio`/`futures`/`async fn` anywhere). Misleading to users searching that category.

Both are baked into the immutable `.crate` file at publish time, so the only fix is a new patch release.

## Files

| File | Change |
|---|---|
| `README.md` | 6 Markdown link conversions (relative → absolute `https://github.com/.../blob/main/...`) + 1 image src conversion (`/raw/main/` for direct image bytes) + Docker quick-install example pin bumped `v0.3.4` → `v0.3.5`. Same-page anchor `#quick-start-runtime` intentionally kept relative. |
| `runtime/Cargo.toml` | (a) `version = "0.3.4"` → `"0.3.5"`. (b) `categories` replaced: dropped `asynchronous`, prepended `artificial-intelligence` (crates.io's official scope: "machine learning, deep learning, large language models, AI agents, and related tooling"). Final: `["artificial-intelligence", "wasm", "command-line-utilities"]`. Validated via `cargo publish --dry-run --locked --allow-dirty` — the crates.io allowlist accepted the AI category. |
| `Cargo.lock` | Single-line `ncp-runtime` self-version bump (`0.3.4` → `0.3.5`). No transitive dep drift; gimli yank fix from v0.3.4 holds. |
| `CHANGELOG.md` | New `## [0.3.5] — 2026-05-27` entry with `### Fixed` (README links) and `### Changed` (categories, version, §3.1 gate, Docker pin). Explains exactly why v0.3.5 exists right after v0.3.4. |
| `docs/PUBLISHING.md` | §3.1 extended with **gate 3** (README-content gate). Unpacks the just-built `.crate` and greps the unpacked README for any bare repo-relative Markdown links (`](docs/...)`, `](BENCHMARK.md)`, etc.) or HTML `src=` references. Fail-hard with non-zero exit. Version-derived (no hand-editing per release). The `(\./)?` regex prefix catches both bare `docs/...` and dot-prefixed `./docs/...` forms — future-proofs against the next person who writes the dot-prefixed style. |

## Pre-commit verification

§3.1 gate 3 was run end-to-end against the current tree before commit:

```
--- detected version: 0.3.5 ---
--- gate 3a: Markdown links grep (should find NONE) ---
OK — no bare relative MD links
--- gate 3b: HTML src grep (should find NONE) ---
OK — no bare relative HTML src
✅ README link gate passed: no bare repo-relative links found in published README
```

`cargo publish --dry-run --locked --allow-dirty` also clean:
```
Packaged 21 files, 211.4KiB (52.2KiB compressed)
Verifying ncp-runtime v0.3.5
Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.50s
warning: aborting upload due to dry run
```

(Size grew from v0.3.4's 210.5 KiB to v0.3.5's 211.4 KiB — absolute URLs are longer than relative paths. Expected.)

## What's NOT in this PR (deliberately deferred)

- `docs/INSTALL.md` has multiple `v0.3.4` references that need updating to `v0.3.5` too. Out of scope for the crates.io render fix — separate doc-refresh PR after v0.3.5 publishes.
- PUBLISHING.md follow-ups for the first-publish GHCR cleanup gotcha + MSYS-bash leading-slash quirk (planned as PR F + PR G — release-ceremony documentation polish, not blocking).

## Test plan

- [ ] PR-time: all 10 required checks pass.
- [ ] Post-merge: re-run §3.1 from clean `main` HEAD (no `--allow-dirty` this time); all 3 gates exit 0 cleanly.
- [ ] Ceremony: push signed `v0.3.5-rc.1`, verify Release + GHCR artifacts (compressed since pipeline is now proven).
- [ ] Ceremony: BOTH-form GHCR cleanup of RC tags (per §6 — note: this time the cleanup loop will succeed on first try because the `ncp` package already has the `v0.3.4` + `0.3.4` tagged versions, so the RC won't be "the last tagged version").
- [ ] Ceremony: push signed `v0.3.5`, verify Release + GHCR + Zenodo archive.
- [ ] Ceremony: fresh crates.io token → `git checkout v0.3.5` → `cargo publish -p ncp-runtime --locked` (live) → revoke token.
- [ ] Ceremony: open https://crates.io/crates/ncp-runtime/0.3.5 and **click every link** — all 12 link conversions + the image src should resolve correctly.
- [ ] Ceremony: confirm `artificial-intelligence` category appears on the crate page sidebar.