### PR TITLE
docs(runtime): add docs.rs crate landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,41 @@ All notable changes to the NCP specification and its reference tooling
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Brick versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). NCP protocol versions follow the versioning policy in the spec (v0.2.x patch-compatible, breaking changes require v0.3.0).
 
+## [0.3.6] — 2026-05-27
+
+### Added
+- **`runtime/src/lib.rs`**: crate-level `//!` documentation block —
+  renders as the docs.rs landing page (https://docs.rs/ncp-runtime).
+  Explains what `ncp-runtime` is, shows the install command, summarizes
+  what the runtime does, links to the project README + install guide +
+  adoption guide + protocol spec, and notes the stability boundary
+  (CLI/runtime stable for evaluation; Rust module API treated as
+  reference-runtime internals until the SDK work lands in Phase 3A.4).
+
+### Fixed
+- **docs.rs landing page**: previously lacked crate-level orientation docs
+  (no `//!` documentation in `lib.rs`), so docs.rs only exposed the
+  module surface without explaining what the runtime is or how to start.
+  v0.3.6 adds the landing page block.
+- **rustdoc HTML-tag-interpretation warnings**: 4 doc comments contained
+  bare angle-bracket constructs (`Option<f64>` in `mapping.rs`, `<ms>`
+  in `ncp-bench.rs`, `<the user's input value>` in `envelope.rs`,
+  `<short_name>.wasm` in `resolver.rs`) that rustdoc was interpreting
+  as HTML tag starts. Wrapped each in inline backticks.
+  Verified clean with rustdoc warnings denied:
+  `RUSTDOCFLAGS="-D warnings" cargo doc -p ncp-runtime --no-deps --all-features`.
+
+### Changed
+- **`README.md`** + **`docs/ADOPTION_GUIDE.md`**: badges row gained
+  crates.io + docs.rs + MSRV; Status line refreshed with concrete
+  install-channel links; ADOPTION_GUIDE §0 Prereqs tightened
+  (`Rust 1.94+`); §1 now leads with `cargo install ncp-runtime --locked`
+  (source build demoted to developer path); §9 production-readiness
+  framing updated to "distribution channels are live as of Phase 3A.1".
+- **`runtime/Cargo.toml`**: crate version bumped `0.3.5` → `0.3.6`.
+  `Cargo.lock` updated to match (only the `ncp-runtime` self-version
+  entry; no transitive dep drift).
+
 ## [0.3.5] — 2026-05-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "ncp-runtime"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ncp-runtime"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/runtime/src/bin/ncp-bench.rs
+++ b/runtime/src/bin/ncp-bench.rs
@@ -11,7 +11,7 @@
 //!                    Outputs both execute_us and end_to_end_us latencies.
 //!
 //! Optional features:
-//!   --simulate-llm-ms <ms>   Inject sleep after matching nodes (models LLM I/O).
+//!   --simulate-llm-ms `<ms>`   Inject sleep after matching nodes (models LLM I/O).
 //!   --concurrency N          Run N worker threads in parallel; report throughput.
 //!   --cold-start             Measure load + compile time separately.
 //!

--- a/runtime/src/envelope.rs
+++ b/runtime/src/envelope.rs
@@ -21,7 +21,7 @@ pub const ROOT_TRIGGER: Trigger<'static> = Trigger {
 ///   carry_state: null
 ///   ctx:         { graph_id, graph_version, node_id, session_id, step, trace_id, trigger }
 ///   graph_refs:  {}
-///   input:       <the user's input value>
+///   input:       `<the user's input value>`
 ///
 /// Input auto-detection:
 ///   - If JSON has top-level "input" key → use its value

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,3 +1,31 @@
+//! NCP reference runtime.
+//!
+//! `ncp-runtime` provides the reference executor and CLI for the
+//! Neural Computation Protocol: composable, auditable WASM Brick graphs
+//! for agentic AI systems.
+//!
+//! Most users start with the `ncp` CLI:
+//!
+//! ```text
+//! cargo install ncp-runtime --version 0.3.6 --locked
+//! ncp --version
+//! ```
+//!
+//! The runtime loads graph manifests, verifies Brick digests, executes
+//! WASM Bricks through Wasmtime, routes results deterministically, and
+//! emits replayable JSONL traces.
+//!
+//! Useful links:
+//!
+//! - [Project README](https://github.com/madeinplutofabio/neural-computation-protocol)
+//! - [Install guide](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/INSTALL.md)
+//! - [Adoption guide](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/ADOPTION_GUIDE.md)
+//! - [Protocol spec](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/spec/ncp-v0.2.3.md)
+//!
+//! Note: the CLI/runtime is stable enough for evaluation and early
+//! integration. Treat the Rust module API as reference-runtime internals
+//! until the SDK work lands.
+
 pub mod engine;
 pub mod envelope;
 pub mod manifest;

--- a/runtime/src/mapping.rs
+++ b/runtime/src/mapping.rs
@@ -117,7 +117,7 @@ pub fn cbor_to_json(value: &CborValue) -> serde_json::Value {
     }
 }
 
-/// Extract output.confidence as Option<f64> from a BrickResult's output.
+/// Extract output.confidence as `Option<f64>` from a BrickResult's output.
 pub fn extract_confidence(value: &CborValue) -> Option<f64> {
     match resolve_path(value, "confidence") {
         Some(CborValue::Float(f)) => Some(f),

--- a/runtime/src/resolver.rs
+++ b/runtime/src/resolver.rs
@@ -88,7 +88,7 @@ fn resolve_brick_dir(
 /// Precedence:
 /// 1. manifest.artifact.path if present
 /// 2. Exactly one .wasm file in directory
-/// 3. <short_name>.wasm
+/// 3. `<short_name>.wasm`
 /// 4. Error listing candidates (sorted for determinism)
 fn select_wasm(brick_id: &str, dir: &Path, artifact_path: &Option<PathBuf>) -> Result<PathBuf> {
     // 1. artifact.path


### PR DESCRIPTION
## Summary

Second half of the post-Phase-3A.1 adoption polish. Companion to PR #17 (already merged on main).

- **Primary fix:** adds a crate-level `//!` block to `runtime/src/lib.rs` so https://docs.rs/ncp-runtime gets an actual orientation landing page instead of a bare module listing.
- **Bonus rustdoc sweep:** 4 doc comments contained bare `<X>` constructs that rustdoc was interpreting as HTML tags. Wrapped each in inline backticks. The runtime crate's docs.rs build now passes with `RUSTDOCFLAGS="-D warnings"`.
- **Bumps to v0.3.6** so the new landing page actually ships to docs.rs (docs.rs builds per-version pages, immutable — v0.3.4 and v0.3.5 stay landing-page-less forever).

## Files

| File | Change |
|---|---|
| `runtime/src/lib.rs` | NEW crate-level `//!` block: intro, `cargo install` example, one-line summary of what the runtime does, 4 absolute-URL Markdown links (README / Install / Adoption / Spec), explicit stability note that Rust module API is reference-runtime internals until SDK work lands in Phase 3A.4. Deliberately no Rust code example — public API isn't promised stable yet. |
| `runtime/src/mapping.rs` | `Option<f64>` → `` `Option<f64>` `` (line 120). Was the only lib-target line rustdoc actively warned on — directly affects docs.rs render. |
| `runtime/src/bin/ncp-bench.rs` | `<ms>` → `` `<ms>` `` (line 14). Pre-existing warning in the bin target. |
| `runtime/src/envelope.rs` | `<the user's input value>` → `` `<the user's input value>` `` (line 24). Semantically a placeholder, not HTML. |
| `runtime/src/resolver.rs` | `<short_name>.wasm` → `` `<short_name>.wasm` `` (line 91). Same reasoning. |
| `runtime/Cargo.toml` | version `0.3.5` → `0.3.6`. |
| `Cargo.lock` | Single-line `ncp-runtime` self-version bump. No transitive dep drift. |
| `CHANGELOG.md` | New `[0.3.6]` entry combining PR #17 content (adopter doc refresh, already on main) and PR J content (docs.rs landing page + rustdoc sweep + version bump). Both ship together when v0.3.6 publishes. |

## Pre-commit verification

```text
$ cargo check -p ncp-runtime
    Checking ncp-runtime v0.3.6
    Finished `dev` profile

$ git diff Cargo.lock
 [[package]]
 name = "ncp-runtime"
-version = "0.3.5"
+version = "0.3.6"
 (single-line diff, no transitive churn)

$ RUSTDOCFLAGS="-D warnings" cargo doc -p ncp-runtime --no-deps --all-features
    Documenting ncp-runtime v0.3.6
    Finished `dev` profile
exit 0 (no rustdoc warnings)

$ cargo test -p ncp-runtime --locked
test result: ok. 5 passed; 0 failed
```

## What's NOT in this PR

- `resolver.rs:60`'s `` `<brick_dir>/<short_name>/` `` — already inside an outer backtick code span, rustdoc treats as literal text, no warning, "fixing" it would fragment the code span.
- Repo metadata changes (set `homepage`, disabled `wiki`) — done via `gh api` outside any PR, not part of release artifacts, deliberately not in CHANGELOG.
- `docs/INSTALL.md` v0.3.5 → v0.3.6 version-pin refresh — same pattern as PR H. Will be a small post-v0.3.6-publish follow-up, not bundled here.

## Why this matters

Adopters who click "Documentation" on https://crates.io/crates/ncp-runtime land on docs.rs. Today that page is empty-feeling — a bare module list with no answer to "what is this crate, how do I use the CLI, where do I go next." After v0.3.6, that page becomes a 30-line orientation block with the answers they're looking for. This is the single highest-leverage docs.rs polish available, given that the work is mechanical and the rendering surface is auto-published on every `cargo publish`.

## Test plan

- [ ] PR-time: all 10 required checks pass.
- [ ] Post-merge: re-run full §3.1 3-gate pre-flight (file-listing + dry-run + README-content) from clean `main` HEAD with v0.3.6 in `runtime/Cargo.toml`.
- [ ] Ceremony: push signed `v0.3.6-rc.1` → verify workflows green, 1 archive smoke (`ncp --version`).
- [ ] Ceremony: §6 RC cleanup (now well-rehearsed, no first-publish gotcha).
- [ ] Ceremony: push signed `v0.3.6` → verify Release + GHCR + Zenodo.
- [ ] Ceremony: fresh crates.io token → `git checkout v0.3.6` → `cargo publish -p ncp-runtime --locked` → revoke token.
- [ ] Ceremony: **open https://docs.rs/ncp-runtime/0.3.6 and confirm the new crate landing page renders correctly** (the key payoff).
- [ ] Ceremony: crates.io README link audit (regression check — should still resolve cleanly per PR E fix).