### PR TITLE
docs(roadmap): avoid false Claude contributor attribution

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -174,11 +174,11 @@ This section reflects the latest released state. Keep it honest and specific; up
 **Deliverables**
 - `ncp-mcp-server` that exposes: **one graph = one MCP tool**
 - Multi-graph support: `--graph a.yaml --graph b.yaml`
-- Transports: stdio (Claude Desktop / CLI hosts) + SSE (web / server hosts)
-- Example: Claude Desktop config + end-to-end test
+- Transports: stdio (MCP desktop / CLI hosts) + SSE (web / server hosts)
+- Example: MCP desktop-host config + end-to-end test
 
 **Exit criteria**
-- A user can "drop a graph into Claude Desktop" as a tool with no glue code
+- A user can drop a graph into an MCP-compatible desktop host as a tool with no glue code
 
 ### 3A.3 LangGraph wrapper (Python)
 


### PR DESCRIPTION
## Summary

GitHub's repository homepage **contributors widget** for this repo displays `@claude` (user id `81847`, Anthropic's official GitHub brand account at https://github.com/claude) as a contributor — even though that account has zero association with the repo. This PR removes the suspected trigger by rephrasing 3 bare "Claude Desktop" mentions in `docs/ROADMAP.md` to generic MCP terminology.

**No release ceremony required.** `docs/ROADMAP.md` is not in the published crate, GitHub Release archives, or GHCR Docker image — it's only served from `main` on github.com. Merge → immediate effect on repo content → wait for GitHub's contributors widget to re-evaluate.

## Investigation evidence

Exhaustive search before drafting this PR. All sources show `@claude` has zero association with the repo:

| Source checked | Result |
|---|---|
| `git log --all --grep='Co-authored-by'` | 0 commits |
| All commit-message trailers (`Signed-off-by`, `Reviewed-by`, etc.) | Only `Signed-off-by: madeinplutofabio` |
| `git grep -i 'claude' \| grep commit` | 0 occurrences of "claude" in any commit body |
| PR authors (#5–#18) | All `madeinplutofabio` |
| Issue authors (#1–#4) | All `madeinplutofabio` |
| Repo collaborators (`gh api .../collaborators`) | Only `madeinplutofabio` (admin) |
| GitHub `/contributors` API endpoint | Only `madeinplutofabio` (72 contributions) |
| GitHub `/graphs/contributors` page | Only `madeinplutofabio` |
| `@claude` user activity on this repo (issues, PRs, stars, watches, reviews, comments) | None |
| **`git grep -i 'claude'` across tracked files (PRE-fix)** | **3 lines in `docs/ROADMAP.md`** (Claude Desktop product references) |
| **Homepage contributors widget (deferred HTML fragment)** | **Shows BOTH `madeinplutofabio` AND `claude` (count: 2)** |

The asymmetry — `/contributors` API returns only the maintainer, but the homepage widget shows `@claude` too — strongly suggests the homepage widget uses a different attribution source (likely a heuristic that scans repo markdown for bare username matches).

The 3 ROADMAP mentions have been in place since commit `ae345ab` (~2 months ago), matching the user-observed onset of the false attribution.

## What this PR changes

`docs/ROADMAP.md` only. Three surgical line edits:

| Before | After |
|---|---|
| `stdio (Claude Desktop / CLI hosts)` | `stdio (MCP desktop / CLI hosts)` |
| `Example: Claude Desktop config + end-to-end test` | `Example: MCP desktop-host config + end-to-end test` |
| `"drop a graph into Claude Desktop"` | `drop a graph into an MCP-compatible desktop host` |

Roadmap meaning preserved (NCP will integrate with MCP-compatible hosts). Product-name specificity intentionally dropped — anyone reading a Phase 3A.2 roadmap entry in 2026 understands what MCP desktop hosts are.

**Strategy choice (why scorched-earth, not markdown-link rephrasing):** wrapping the mentions in markdown link form `[Claude Desktop](url)` would also have worked IF GitHub's heuristic ignores text inside links. But that's a bet on undocumented heuristic behavior. Removing the bare word "Claude" entirely is a guarantee. For a fix where iteration cost is high (PR + merge + days-of-waiting + re-check), guarantee beats bet.

## Verification

```text
$ git grep -i 'claude'
(no output — zero matches across all tracked files post-fix)
```

## What happens after merge

1. The repo content no longer contains the trigger string.
2. GitHub's homepage contributors widget should re-evaluate within ~days (the widget is computed by a background-indexed system, not on-demand from `main`).
3. **If `@claude` still appears in the widget after ~1 week**, file a GitHub support ticket at https://support.github.com/contact with the evidence above. Suggested ticket text:

   > The homepage contributors widget for `madeinplutofabio/neural-computation-protocol` shows `@claude` as a contributor, but `@claude` has no commits, PRs, issues, comments, stars, or watches on this repo. The `/graphs/contributors` page and `/contributors` API correctly show only my account. This appears to be a false attribution caused by product-name text in markdown, not actual repository contribution. Please remove the incorrect homepage attribution.

## Forward-maintenance note (not blocking this PR)

Any future doc that introduces bare "Claude" (e.g., a CHANGELOG entry naming a `claude-classifier` brick, a blog post mentioning Claude Opus N) could re-trigger the same heuristic. Mitigation pattern to internalize: use qualifier-first phrasing ("Anthropic Claude", "Claude Code agent") or generic product-family terms ("MCP host") in tracked markdown.

## Test plan

- [ ] PR-time: all 10 required checks pass (this is a docs-only change, no code paths exercised).
- [ ] Post-merge: visually inspect https://github.com/madeinplutofabio/neural-computation-protocol — the @claude avatar should disappear from the right-sidebar Contributors widget within ~days (NOT immediately; widget is async-indexed).
- [ ] If @claude persists after ~1 week: file the support ticket above.