### PR TITLE
chore(mcp): scaffold ncp-mcp-server crate (PR 3A.2-B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,6 +942,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ncp-mcp-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ncp-runtime",
+ "serde_json",
+]
+
+[[package]]
 name = "ncp-runtime"
 version = "0.3.6"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "runtime",
   "bricks/echo",
   "bricks/classifier-stub",
+  "crates/ncp-mcp-server",
 ]
 default-members = ["runtime"]
 resolver = "2"

--- a/crates/ncp-mcp-server/Cargo.toml
+++ b/crates/ncp-mcp-server/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "ncp-mcp-server"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "MCP adapter for NCP — exposes auditable WASM Brick graphs as MCP tools"
+repository = "https://github.com/madeinplutofabio/neural-computation-protocol"
+homepage = "https://github.com/madeinplutofabio/neural-computation-protocol"
+readme = "README.md"
+keywords = ["mcp", "agentic-ai", "wasm", "ncp", "adapter"]
+categories = ["artificial-intelligence", "command-line-utilities"]
+include = [
+    "src/**",
+    "tests/**",
+    "Cargo.toml",
+    "README.md",
+    "LICENSE",
+    "NOTICE",
+]
+
+[lib]
+name = "ncp_mcp_server"
+path = "src/lib.rs"
+
+[[bin]]
+name = "ncp-mcp-server"
+path = "src/main.rs"
+
+[dependencies]
+# Per docs/MCP_ADAPTER.md §9: version + path together. Cargo prefers `path`
+# during workspace development; published crate uses the `version` requirement.
+ncp-runtime = { version = "0.3.6", path = "../../runtime" }
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+serde_json = "1"
+
+# Intentionally NO tokio and NO rmcp in PR B — those land in PR C when the
+# MCP protocol implementation arrives. PR B is plumbing only: graph loading,
+# tool-name derivation, uniqueness validation, trace-dir validation,
+# RuntimeContext Send+Sync compile assertion.

--- a/crates/ncp-mcp-server/LICENSE
+++ b/crates/ncp-mcp-server/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Fabio Marcello Salvadori
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/ncp-mcp-server/NOTICE
+++ b/crates/ncp-mcp-server/NOTICE
@@ -1,0 +1,7 @@
+NCP — Neural Computation Protocol
+Copyright 2026 Fabio Marcello Salvadori
+
+This product includes software developed by Fabio Marcello Salvadori.
+
+Licensed under the Apache License, Version 2.0.
+See the LICENSE file for the full license text.

--- a/crates/ncp-mcp-server/README.md
+++ b/crates/ncp-mcp-server/README.md
@@ -1,0 +1,72 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 Fabio Marcello Salvadori
+-->
+
+# ncp-mcp-server
+
+A stdio [Model Context Protocol](https://modelcontextprotocol.io) adapter for
+[NCP](https://github.com/madeinplutofabio/neural-computation-protocol) —
+exposes auditable WASM Brick graphs as MCP tools that any MCP-compatible host
+can call.
+
+**One graph = one MCP tool.** Configure your MCP-compatible host to launch
+`ncp-mcp-server --graph graph.yaml`, and that graph becomes a callable tool.
+No glue code, no protocol translation in your app.
+
+## Install
+
+From crates.io, after `v0.1.0` is published later in Phase 3A.2:
+
+```bash
+cargo install ncp-mcp-server --locked
+ncp-mcp-server --version
+```
+
+Until then, install from source:
+
+```bash
+git clone https://github.com/madeinplutofabio/neural-computation-protocol.git
+cd neural-computation-protocol
+cargo install --path crates/ncp-mcp-server --locked
+```
+
+Requires Rust 1.94+.
+
+## Quick example
+
+Multi-graph support from day one — repeat `--graph` for each graph:
+
+```bash
+ncp-mcp-server \
+  --graph path/to/triage-graph.yaml \
+  --graph path/to/extract-graph.yaml \
+  --trace-dir /tmp/ncp-mcp-traces
+```
+
+Each graph becomes one MCP tool with a name derived from the graph's
+`graph_id`. JSON-RPC traffic flows on stdin/stdout; diagnostics go to stderr;
+per-call execution traces, when `--trace-dir` is set, land in
+`<dir>/<trace_id>.jsonl`.
+
+## Documentation
+
+- [Design doc](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/MCP_ADAPTER.md) — binding architectural decisions for this adapter
+- [NCP project README](https://github.com/madeinplutofabio/neural-computation-protocol) — what NCP is and why
+- [NCP install guide](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/INSTALL.md) — runtime + adapter install paths
+- [NCP adoption guide](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/ADOPTION_GUIDE.md) — how to use NCP in your stack
+- [NCP protocol spec](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/spec/ncp-v0.2.3.md) — the NCP protocol this adapter exposes
+- [MCP spec](https://modelcontextprotocol.io/specification/2025-11-25) — the protocol this adapter implements
+
+## Status
+
+`v0.1.0` targets MCP spec **2025-11-25** over **stdio transport only**.
+Streamable HTTP transport is deferred to a future release.
+
+The CLI is the stable interface. The Rust module API is treated as
+reference-implementation internals until adopter feedback shapes a stable
+public surface.
+
+## License
+
+Apache-2.0 — see [LICENSE](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/LICENSE) and [NOTICE](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/NOTICE).

--- a/crates/ncp-mcp-server/src/cli.rs
+++ b/crates/ncp-mcp-server/src/cli.rs
@@ -1,0 +1,122 @@
+//! CLI parsing, graph loading, and startup validation.
+//!
+//! This module is the entry-point logic that `src/main.rs` delegates to.
+//! In PR B, it loads each `--graph` manifest via `RuntimeContext::load`,
+//! derives MCP tool names via [`crate::naming`], validates uniqueness,
+//! validates the `--trace-dir` (if set), and prints a startup summary to
+//! stderr. **No MCP protocol traffic** — that arrives in PR C.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+use clap::Parser;
+use ncp_runtime::RuntimeContext;
+
+use crate::naming;
+
+/// `ncp-mcp-server` — MCP adapter for NCP graphs.
+#[derive(Parser, Debug)]
+#[command(
+    name = "ncp-mcp-server",
+    version,
+    about = "Stdio MCP adapter exposing NCP graphs as MCP tools"
+)]
+pub struct Cli {
+    /// Path to an NCP graph manifest (repeat the flag for multiple graphs).
+    #[arg(long = "graph", required = true, value_name = "PATH")]
+    pub graphs: Vec<PathBuf>,
+
+    /// Directory containing brick subdirectories.
+    #[arg(
+        long = "brick-dir",
+        default_value = "examples/bricks",
+        value_name = "DIR"
+    )]
+    pub brick_dir: PathBuf,
+
+    /// Path to a YAML/JSON brick-map file (overrides --brick-dir for listed brick IDs).
+    #[arg(long = "brick-map", value_name = "FILE")]
+    pub brick_map: Option<PathBuf>,
+
+    /// Directory for per-call trace files (`<dir>/<trace_id>.jsonl`).
+    /// If absent, traces are dropped (NullTrace).
+    #[arg(long = "trace-dir", value_name = "DIR")]
+    pub trace_dir: Option<PathBuf>,
+}
+
+/// Validates `--trace-dir` per docs/MCP_ADAPTER.md §12:
+/// - Returns `Ok(None)` if not set.
+/// - Creates the directory recursively if it doesn't exist.
+/// - Fails if the path exists but is not a directory.
+/// - Returns the canonicalized absolute path.
+pub fn validate_trace_dir(trace_dir: Option<&Path>) -> Result<Option<PathBuf>> {
+    let Some(dir) = trace_dir else {
+        return Ok(None);
+    };
+
+    if dir.exists() {
+        if !dir.is_dir() {
+            return Err(anyhow!(
+                "--trace-dir `{}` exists but is not a directory",
+                dir.display()
+            ));
+        }
+    } else {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("failed to create --trace-dir `{}`", dir.display()))?;
+    }
+
+    let canonical = std::fs::canonicalize(dir)
+        .with_context(|| format!("failed to canonicalize --trace-dir `{}`", dir.display()))?;
+    Ok(Some(canonical))
+}
+
+/// PR B startup flow: parse CLI, validate trace-dir, load each graph,
+/// derive tool names, validate uniqueness, print summary, exit 0.
+///
+/// PR C extends this to wire up the MCP server after the summary line.
+pub fn run() -> Result<()> {
+    let cli = Cli::parse();
+
+    // 1. Validate + canonicalize --trace-dir (per §12).
+    //    The canonicalized path is unused in PR B (no MCP traffic = no trace
+    //    writes). PR C will use it to construct per-call trace files.
+    let _trace_dir = validate_trace_dir(cli.trace_dir.as_deref())?;
+
+    // 2. Load each graph via RuntimeContext::load() — validates the graph
+    //    enough to construct a RuntimeContext (manifest parses, bricks resolve).
+    //    Collect (path, derived tool name) pairs.
+    //    PR B drops the loaded contexts after the summary; PR C will keep
+    //    them in a HashMap<ToolName, Arc<RuntimeContext>> for tools/call.
+    let mut pairs: Vec<(PathBuf, String)> = Vec::with_capacity(cli.graphs.len());
+    for graph_path in &cli.graphs {
+        let ctx = RuntimeContext::load(graph_path, &cli.brick_dir, cli.brick_map.as_deref())
+            .with_context(|| format!("failed to load graph `{}`", graph_path.display()))?;
+
+        let tool_name = naming::graph_id_to_tool_name(ctx.graph_id()).with_context(|| {
+            format!(
+                "failed to derive tool name from graph `{}`",
+                graph_path.display()
+            )
+        })?;
+
+        pairs.push((graph_path.clone(), tool_name));
+    }
+
+    // 3. Validate no two graphs derive the same tool name.
+    naming::validate_no_collisions(&pairs)?;
+
+    // 4. Print loaded-tool summary to stderr.
+    //    Stdout is reserved for JSON-RPC protocol traffic (per §7); even in
+    //    PR B where no protocol is wired up, we follow the discipline.
+    let names: Vec<&str> = pairs.iter().map(|(_, n)| n.as_str()).collect();
+    eprintln!(
+        "loaded {} graph(s) as MCP tools: {}",
+        names.len(),
+        names.join(", ")
+    );
+
+    // 5. PR B exits cleanly here. PR C replaces this point with the MCP
+    //    server loop (initialize / tools/list / tools/call over stdio).
+    Ok(())
+}

--- a/crates/ncp-mcp-server/src/lib.rs
+++ b/crates/ncp-mcp-server/src/lib.rs
@@ -1,0 +1,50 @@
+//! # ncp-mcp-server
+//!
+//! A stdio [Model Context Protocol] adapter for [NCP] — exposes auditable
+//! WASM Brick graphs as MCP tools that any MCP-compatible host can call.
+//!
+//! One graph = one MCP tool. Configure your MCP-compatible host to launch
+//! `ncp-mcp-server --graph graph.yaml`, and that graph becomes a callable
+//! tool with no glue code.
+//!
+//! ## Install
+//!
+//! ```text
+//! cargo install ncp-mcp-server --locked
+//! ```
+//!
+//! Then point your MCP-compatible host's tool config at the binary. See the
+//! [adapter README] for source-install and crates.io-install instructions,
+//! and the [design doc] for binding architectural decisions.
+//!
+//! ## Stability
+//!
+//! `v0.1.0` targets MCP spec 2025-11-25 over stdio transport only.
+//! Streamable HTTP transport is deferred to a future release.
+//!
+//! The CLI is the stable interface. The Rust module API exposed by this crate
+//! is treated as reference-implementation internals until adopter feedback
+//! shapes a stable public surface. Treat module re-exports as private to the
+//! binary.
+//!
+//! ## Links
+//!
+//! - [Design doc](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/MCP_ADAPTER.md)
+//! - [Project README](https://github.com/madeinplutofabio/neural-computation-protocol)
+//! - [Install guide](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/INSTALL.md)
+//! - [Adoption guide](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/ADOPTION_GUIDE.md)
+//! - [NCP protocol spec](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/spec/ncp-v0.2.3.md)
+//! - [MCP spec](https://modelcontextprotocol.io/specification/2025-11-25)
+//!
+//! [Model Context Protocol]: https://modelcontextprotocol.io
+//! [NCP]: https://github.com/madeinplutofabio/neural-computation-protocol
+//! [adapter README]: https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/crates/ncp-mcp-server/README.md
+//! [design doc]: https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/MCP_ADAPTER.md
+
+#[doc(hidden)]
+pub mod cli;
+
+#[doc(hidden)]
+pub mod naming;
+
+mod send_sync_check;

--- a/crates/ncp-mcp-server/src/main.rs
+++ b/crates/ncp-mcp-server/src/main.rs
@@ -1,0 +1,9 @@
+//! Binary entrypoint for `ncp-mcp-server`.
+//!
+//! Thin wrapper that delegates to `ncp_mcp_server::cli::run`. All
+//! application logic lives in the library; this file exists to satisfy
+//! Cargo's `[[bin]]` target.
+
+fn main() -> anyhow::Result<()> {
+    ncp_mcp_server::cli::run()
+}

--- a/crates/ncp-mcp-server/src/naming.rs
+++ b/crates/ncp-mcp-server/src/naming.rs
@@ -1,0 +1,187 @@
+//! Tool-name derivation rule (locked, per docs/MCP_ADAPTER.md §3).
+//!
+//! Maps NCP graph IDs to MCP tool names by replacing any character not in
+//! `[A-Za-z0-9_.-]` with `_`. Dots are preserved (the MCP spec allows dots
+//! in tool names; `admin.tools.list` is the spec's own example).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Result};
+
+/// Maximum tool-name length per MCP spec.
+pub const MAX_TOOL_NAME_LEN: usize = 128;
+
+/// Derives an MCP tool name from a graph ID per the locked rule
+/// (see docs/MCP_ADAPTER.md §3).
+///
+/// Replaces any character not in `[A-Za-z0-9_.-]` with `_`. Returns an
+/// error if the derived name is empty or exceeds [`MAX_TOOL_NAME_LEN`].
+///
+/// Note: because the rule REPLACES (not removes) disallowed characters,
+/// the derived name is empty only when the input is empty. An input like
+/// `///` produces `___` (a valid, non-empty tool name), not an error.
+///
+/// Since the function only emits ASCII characters, byte length equals
+/// character count — no need to disambiguate.
+pub fn graph_id_to_tool_name(graph_id: &str) -> Result<String> {
+    let derived: String = graph_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    if derived.is_empty() {
+        return Err(anyhow!(
+            "derived tool name is empty (graph_id `{}` was empty)",
+            graph_id
+        ));
+    }
+    if derived.len() > MAX_TOOL_NAME_LEN {
+        return Err(anyhow!(
+            "derived tool name `{}` exceeds MCP spec limit ({} > {})",
+            derived,
+            derived.len(),
+            MAX_TOOL_NAME_LEN
+        ));
+    }
+    Ok(derived)
+}
+
+/// Validates that a slice of (graph-path, tool-name) pairs contains no
+/// duplicate tool names.
+///
+/// On collision, returns an error naming both graph paths that produced
+/// the same tool name. Adopters must rename or rework one of the
+/// colliding graphs.
+pub fn validate_no_collisions(pairs: &[(PathBuf, String)]) -> Result<()> {
+    let mut seen: HashMap<&str, &Path> = HashMap::new();
+    for (path, name) in pairs {
+        if let Some(prior) = seen.insert(name.as_str(), path.as_path()) {
+            return Err(anyhow!(
+                "tool name `{}` derived from both `{}` and `{}` — graphs must produce unique tool names",
+                name,
+                prior.display(),
+                path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // ── graph_id_to_tool_name ───────────────────────────────────────────
+
+    #[test]
+    fn simple_reverse_domain_case() {
+        // Spec-aligned graph_id: all chars already in allowed set.
+        assert_eq!(
+            graph_id_to_tool_name("org.ncp-examples.echo-pipeline").unwrap(),
+            "org.ncp-examples.echo-pipeline"
+        );
+    }
+
+    #[test]
+    fn dots_preserved() {
+        assert_eq!(graph_id_to_tool_name("a.b.c").unwrap(), "a.b.c");
+    }
+
+    #[test]
+    fn hyphens_preserved() {
+        assert_eq!(graph_id_to_tool_name("a-b-c").unwrap(), "a-b-c");
+    }
+
+    #[test]
+    fn underscores_preserved() {
+        assert_eq!(graph_id_to_tool_name("a_b_c").unwrap(), "a_b_c");
+    }
+
+    #[test]
+    fn digits_preserved() {
+        assert_eq!(graph_id_to_tool_name("a0.b1.c2").unwrap(), "a0.b1.c2");
+    }
+
+    #[test]
+    fn slashes_become_underscores() {
+        assert_eq!(graph_id_to_tool_name("foo/bar/baz").unwrap(), "foo_bar_baz");
+    }
+
+    #[test]
+    fn mixed_allowed_and_disallowed() {
+        assert_eq!(
+            graph_id_to_tool_name("foo.bar/baz@qux").unwrap(),
+            "foo.bar_baz_qux"
+        );
+    }
+
+    #[test]
+    fn unicode_codepoints_each_become_one_underscore() {
+        // Each non-ASCII code point becomes a single `_`.
+        // "café" = c + a + f + é (4 code points; é is U+00E9 → `_`).
+        assert_eq!(graph_id_to_tool_name("café").unwrap(), "caf_");
+    }
+
+    #[test]
+    fn all_disallowed_chars_become_all_underscores_not_error() {
+        // Disallowed chars are REPLACED with `_`, not removed.
+        // "///" → "___" (a valid, non-empty tool name).
+        assert_eq!(graph_id_to_tool_name("///").unwrap(), "___");
+    }
+
+    #[test]
+    fn empty_input_errors() {
+        let err = graph_id_to_tool_name("").unwrap_err().to_string();
+        assert!(err.contains("derived tool name is empty"), "got: {err}");
+    }
+
+    #[test]
+    fn at_max_len_succeeds() {
+        let name = "a".repeat(MAX_TOOL_NAME_LEN);
+        assert_eq!(graph_id_to_tool_name(&name).unwrap(), name);
+    }
+
+    #[test]
+    fn over_max_len_errors() {
+        let name = "a".repeat(MAX_TOOL_NAME_LEN + 1);
+        let err = graph_id_to_tool_name(&name).unwrap_err().to_string();
+        assert!(err.contains("exceeds MCP spec limit"), "got: {err}");
+    }
+
+    // ── validate_no_collisions ──────────────────────────────────────────
+
+    #[test]
+    fn no_collisions_passes() {
+        let pairs = vec![
+            (PathBuf::from("a.yaml"), "tool_a".to_string()),
+            (PathBuf::from("b.yaml"), "tool_b".to_string()),
+        ];
+        assert!(validate_no_collisions(&pairs).is_ok());
+    }
+
+    #[test]
+    fn empty_input_passes() {
+        let pairs: Vec<(PathBuf, String)> = vec![];
+        assert!(validate_no_collisions(&pairs).is_ok());
+    }
+
+    #[test]
+    fn collision_errors_and_names_both_paths() {
+        let pairs = vec![
+            (PathBuf::from("a.yaml"), "shared".to_string()),
+            (PathBuf::from("b.yaml"), "shared".to_string()),
+        ];
+        let err = validate_no_collisions(&pairs).unwrap_err().to_string();
+        assert!(err.contains("a.yaml"), "got: {err}");
+        assert!(err.contains("b.yaml"), "got: {err}");
+        assert!(err.contains("shared"), "got: {err}");
+    }
+}

--- a/crates/ncp-mcp-server/src/send_sync_check.rs
+++ b/crates/ncp-mcp-server/src/send_sync_check.rs
@@ -1,0 +1,42 @@
+//! Compile-time assertions that the NCP runtime types we depend on satisfy
+//! the bounds required by `tokio::task::spawn_blocking` (see
+//! docs/MCP_ADAPTER.md §11).
+//!
+//! The async-to-sync bridge in PR C will use:
+//!
+//! ```text
+//! tokio::task::spawn_blocking(move || -> anyhow::Result<ExecutionReport> {
+//!     ctx.execute(...)  // ctx: Arc<RuntimeContext>
+//! })
+//! ```
+//!
+//! `spawn_blocking<F, R>(f: F) -> JoinHandle<R>` requires:
+//!
+//! - `F: FnOnce() -> R + Send + 'static`: every captured value must be Send. For `Arc<T>` this requires `T: Send + Sync`.
+//! - `R: Send + 'static`: `anyhow::Result<ExecutionReport>` must be Send.
+//!
+//! If either assertion below fails to compile, PR C cannot use the
+//! `spawn_blocking` pattern. The architecture must pivot to the
+//! worker-thread fallback (single owner, channel-fed jobs) per §11.
+//!
+//! Catching this at PR B compile time avoids discovering it inside PR C's
+//! protocol code, where the architecture change would be much more
+//! disruptive.
+
+fn assert_send_sync<T: Send + Sync>() {}
+fn assert_send<T: Send>() {}
+
+#[allow(dead_code)]
+fn _runtime_context_must_be_send_sync() {
+    // Required because the closure captures `Arc<RuntimeContext>`; Arc is Send
+    // iff its inner type is Send + Sync.
+    assert_send_sync::<ncp_runtime::RuntimeContext>();
+}
+
+#[allow(dead_code)]
+fn _execute_result_must_be_send() {
+    // Required because the closure returns `anyhow::Result<ExecutionReport>`
+    // and spawn_blocking's JoinHandle<R> bound requires R: Send.
+    // `Result<T, E>: Send` iff `T: Send` AND `E: Send`; this exercises both.
+    assert_send::<anyhow::Result<ncp_runtime::ExecutionReport>>();
+}

--- a/crates/ncp-mcp-server/tests/loading.rs
+++ b/crates/ncp-mcp-server/tests/loading.rs
@@ -1,0 +1,232 @@
+//! Integration tests for the `ncp-mcp-server` binary (PR B scope).
+//!
+//! These tests drive the binary as a subprocess via Cargo's
+//! `CARGO_BIN_EXE_ncp-mcp-server` env var (avoids hardcoded `target/debug/...`
+//! paths that break on Windows `.exe` suffix or release profile).
+//!
+//! Coverage:
+//! - One graph loads, summary printed, exit 0, stdout empty.
+//! - Two distinct graphs load, both names printed, exit 0, stdout empty.
+//! - Two colliding graphs fail at startup with clear error, stdout empty.
+//! - `--trace-dir` pointing at an existing file (not a dir) errors at
+//!   startup, stdout empty.
+//! - `--trace-dir` pointing at a non-existent directory creates it,
+//!   exit 0, stdout empty.
+//!
+//! Every test asserts stdout is EMPTY because PR B has no MCP protocol
+//! traffic yet — the binary should write only to stderr. This catches
+//! stdout pollution early, before PR C's full process-level JSON-RPC
+//! test (per docs/MCP_ADAPTER.md §7 logging discipline).
+//!
+//! All tests construct paths relative to `CARGO_MANIFEST_DIR` so they work
+//! regardless of the test runner's CWD.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+/// Absolute path to the built `ncp-mcp-server` binary (provided by Cargo).
+fn binary() -> &'static str {
+    env!("CARGO_BIN_EXE_ncp-mcp-server")
+}
+
+/// Absolute path to the workspace root (two levels up from this crate).
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent() // crates/
+        .and_then(|p| p.parent()) // workspace root
+        .expect("CARGO_MANIFEST_DIR has at least two parents")
+        .to_path_buf()
+}
+
+fn echo_pipeline_graph() -> PathBuf {
+    workspace_root().join("examples/graphs/echo-pipeline/graph.yaml")
+}
+
+fn echo_chain_graph() -> PathBuf {
+    workspace_root().join("examples/graphs/echo-chain/graph.yaml")
+}
+
+fn brick_dir() -> PathBuf {
+    workspace_root().join("examples/bricks")
+}
+
+/// Returns a unique temp path for this test, deleting any prior version.
+/// Tests should clean up at the end, but this guard handles stale state
+/// from prior failed runs.
+fn unique_temp_path(test_name: &str) -> PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "ncp-mcp-server-test-{}-{}",
+        test_name,
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&p);
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+fn run_binary(args: &[&str]) -> Output {
+    Command::new(binary())
+        .args(args)
+        .output()
+        .expect("failed to spawn ncp-mcp-server binary")
+}
+
+fn assert_stdout_empty(output: &Output) {
+    assert!(
+        output.stdout.is_empty(),
+        "stdout should be empty in PR B:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_stderr_contains(output: &Output, needle: &str) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(needle),
+        "stderr did not contain `{needle}`:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        stderr
+    );
+}
+
+// ── happy path: single graph ───────────────────────────────────────────
+
+#[test]
+fn one_graph_loads_and_prints_tool_name() {
+    let output = run_binary(&[
+        "--graph",
+        echo_pipeline_graph().to_str().unwrap(),
+        "--brick-dir",
+        brick_dir().to_str().unwrap(),
+    ]);
+
+    assert_stdout_empty(&output);
+
+    assert!(
+        output.status.success(),
+        "exit non-zero:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_stderr_contains(&output, "loaded 1 graph(s) as MCP tools");
+    assert_stderr_contains(&output, "org.ncp-examples.echo-pipeline");
+}
+
+// ── happy path: two distinct graphs ────────────────────────────────────
+
+#[test]
+fn two_distinct_graphs_load_both_names_printed() {
+    let output = run_binary(&[
+        "--graph",
+        echo_pipeline_graph().to_str().unwrap(),
+        "--graph",
+        echo_chain_graph().to_str().unwrap(),
+        "--brick-dir",
+        brick_dir().to_str().unwrap(),
+    ]);
+
+    assert_stdout_empty(&output);
+
+    assert!(
+        output.status.success(),
+        "exit non-zero:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_stderr_contains(&output, "loaded 2 graph(s) as MCP tools");
+    assert_stderr_contains(&output, "org.ncp-examples.echo-pipeline");
+    assert_stderr_contains(&output, "org.ncp-examples.echo-chain");
+}
+
+// ── collision: same graph loaded twice ─────────────────────────────────
+
+#[test]
+fn two_colliding_graphs_fail_with_clear_error() {
+    // Loading the same graph path twice produces the same derived tool name
+    // → collision detected at startup.
+    let path = echo_pipeline_graph();
+    let path_str = path.to_str().unwrap();
+
+    let output = run_binary(&[
+        "--graph",
+        path_str,
+        "--graph",
+        path_str,
+        "--brick-dir",
+        brick_dir().to_str().unwrap(),
+    ]);
+
+    assert_stdout_empty(&output);
+
+    assert!(
+        !output.status.success(),
+        "expected exit non-zero, got success:\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_stderr_contains(&output, "tool name");
+    assert_stderr_contains(&output, "must produce unique tool names");
+}
+
+// ── --trace-dir validation: existing file is rejected ──────────────────
+
+#[test]
+fn trace_dir_pointing_at_existing_file_errors() {
+    // Create a regular file (not a dir) at the trace-dir location.
+    let target = unique_temp_path("trace-dir-is-file");
+    std::fs::write(&target, b"hello").expect("failed to create test file");
+
+    let output = run_binary(&[
+        "--graph",
+        echo_pipeline_graph().to_str().unwrap(),
+        "--brick-dir",
+        brick_dir().to_str().unwrap(),
+        "--trace-dir",
+        target.to_str().unwrap(),
+    ]);
+
+    assert_stdout_empty(&output);
+
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let _ = std::fs::remove_file(&target); // cleanup
+
+    assert!(
+        !output.status.success(),
+        "expected exit non-zero, got success:\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("exists but is not a directory"),
+        "stderr did not contain expected message:\nstderr: {stderr}"
+    );
+}
+
+// ── --trace-dir validation: non-existent dir is created ────────────────
+
+#[test]
+fn trace_dir_pointing_at_non_existent_path_is_created() {
+    let target = unique_temp_path("trace-dir-non-existent");
+    assert!(!target.exists(), "test setup: target should not exist yet");
+
+    let output = run_binary(&[
+        "--graph",
+        echo_pipeline_graph().to_str().unwrap(),
+        "--brick-dir",
+        brick_dir().to_str().unwrap(),
+        "--trace-dir",
+        target.to_str().unwrap(),
+    ]);
+
+    assert_stdout_empty(&output);
+
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let exists = target.exists();
+    let is_dir = target.is_dir();
+    let _ = std::fs::remove_dir_all(&target); // cleanup
+
+    assert!(output.status.success(), "exit non-zero:\nstderr: {stderr}");
+    assert!(exists, "trace-dir was not created");
+    assert!(is_dir, "trace-dir exists but is not a directory");
+}

--- a/docs/MCP_ADAPTER.md
+++ b/docs/MCP_ADAPTER.md
@@ -60,6 +60,21 @@ a clear error message naming both colliding graph manifests. No
 runtime hash-shortening or silent disambiguation — fail-fast is
 transparent.
 
+### CLI surface
+
+The adapter binary accepts these flags:
+
+| Flag | Required | Default | Purpose |
+|---|---|---|---|
+| `--graph <PATH>` | yes (repeat for multi-graph) | — | Path to an NCP graph manifest. Each occurrence loads one graph; together they map to one MCP tool each. |
+| `--brick-dir <DIR>` | no | `examples/bricks` | Directory containing brick subdirectories. Passed through to `RuntimeContext::load()`. |
+| `--brick-map <FILE>` | no | — | Brick-map file; overrides `--brick-dir` for listed brick IDs. Passed through to `RuntimeContext::load()`. |
+| `--trace-dir <DIR>` | no | — | Directory for per-call trace files. See §12 for full semantics. If absent, traces are dropped (`NullTrace`). |
+
+`--brick-dir` and `--brick-map` mirror the existing `ncp` runtime CLI semantics — adopters who already use the runtime CLI know these flags.
+
+The MCP protocol layer (`initialize` / `tools/list` / `tools/call`) takes no CLI flags; transport is implicit (stdio).
+
 ---
 
 ## 3. Tool-name derivation rule
@@ -91,7 +106,7 @@ mishandle them" was client-rumor, not spec-aligned.
 
 | Condition | Behavior |
 |---|---|
-| Derived name is empty (graph_id had no allowed chars) | startup fail |
+| Derived name is empty (graph_id was empty) | startup fail |
 | Derived name exceeds 128 chars | startup fail |
 | Two loaded graphs derive the same name | startup fail (name both colliding manifests) |
 


### PR DESCRIPTION
## Summary

PR B of Phase 3A.2 — adds the `ncp-mcp-server` workspace crate at `crates/ncp-mcp-server/` per the locked architecture from PR A's design doc. **Plumbing only:** graph loading, tool-name derivation, uniqueness validation, trace-dir validation, and Send+Sync compile-time assertions. NO MCP protocol logic, NO tokio, NO rmcp — those land in PR C against this foundation.

The crate publishes-ready from day one (full metadata, lib.rs with `//!` docs.rs landing block, LICENSE + NOTICE included) so PR E's eventual v0.1.0 release ceremony has no last-minute scaffolding work.

## Why "plumbing only"?

PR A locked seventeen architectural decisions. Splitting the implementation across PRs B → C → D → E keeps each PR independently reviewable:

- **PR B (this PR):** workspace scaffolding, CLI surface, graph loading, naming, type-bound verification. Reviewable as pure Cargo/Rust plumbing.
- **PR C:** MCP protocol layer (`initialize` / `tools/list` / `tools/call`) on top of PR B's foundation. Reviewable as protocol-implementation work.
- **PR D:** example MCP host config + extended CI smoke job.
- **PR E:** publish `ncp-mcp-server v0.1.0` to crates.io.

PR B's exit gates verify the foundation supports PR C's planned design without requiring any of PR C's code to be written.

## Critical verification results

| Item | Result | Why it matters |
|---|---|---|
| `RuntimeContext: Send + Sync` | ✅ verified at compile time | PR C uses `spawn_blocking` pattern (not worker-thread fallback per design §11) |
| `anyhow::Result<ExecutionReport>: Send` | ✅ verified at compile time | PR C's `tokio::task::spawn_blocking` return-type bound is satisfied |
| `Cargo.lock` present in published `.crate` | ✅ confirmed via `cargo package --list` | PR E can document `cargo install ncp-mcp-server --locked` as a reproducible install path |
| README.md + LICENSE + NOTICE in `.crate` | ✅ confirmed via `cargo package --list` | Apache §4(d) compliance + crates.io render works on first publish |

## Files

**Workspace integration (3 files):**

| File | Change |
|---|---|
| `Cargo.toml` (workspace) | edit — adds `"crates/ncp-mcp-server"` to `members`. `default-members` stays as just `["runtime"]` so default builds aren't slowed by the new crate. |
| `Cargo.lock` | regenerated — adds single 10-line entry for `ncp-mcp-server v0.1.0`. **Zero transitive dep changes** (no churn on ncp-runtime, gimli, etc.). |
| `docs/MCP_ADAPTER.md` | 2 edits: §3 wording fix (`graph_id had no allowed chars` → `graph_id was empty` — matches `naming.rs`'s actual behavior since the rule REPLACES disallowed chars, doesn't remove them); §2 CLI surface table added (documents `--graph`, `--brick-dir`, `--brick-map`, `--trace-dir`). Placed inside §2 to avoid renumbering §3–§17 (would invalidate cross-references in source code comments). |

**New crate files (10 files):**

| File | Purpose |
|---|---|
| `crates/ncp-mcp-server/Cargo.toml` | `name = "ncp-mcp-server"`, `version = "0.1.0"`, full publish-readiness metadata (description, repository, homepage, readme, keywords, categories `["artificial-intelligence", "command-line-utilities"]`, explicit `include` array). Path+version dep on `ncp-runtime` per §9. Deps: `ncp-runtime`, `anyhow`, `clap` (derive), `serde_json`. **NO tokio. NO rmcp.** |
| `crates/ncp-mcp-server/README.md` | Adapter-specific crate landing page. Absolute GitHub URLs only (applies v0.3.4-class crates.io render lesson). Pre-publish install ordering documents source-install first since `cargo install ncp-mcp-server` won't work until PR E publishes. |
| `crates/ncp-mcp-server/LICENSE` + `NOTICE` | Verbatim copies of `runtime/{LICENSE,NOTICE}` (themselves verbatim copies of repo-root). Required because Cargo's `include` array silently strips `..` paths; local copies are the established Phase 3A.1 workaround. Verified byte-identical via `cmp -s`. |
| `crates/ncp-mcp-server/src/lib.rs` | Crate root with `//!` docs.rs landing page block from day one (applies PR J Phase 3A.1 lesson). `#[doc(hidden)]` on `pub mod cli` + `pub mod naming` so docs.rs doesn't invite adopters to depend on internal module surface that's not yet stable. |
| `crates/ncp-mcp-server/src/main.rs` | Thin binary entrypoint — single line, delegates to `ncp_mcp_server::cli::run`. Will get `#![deny(clippy::print_stdout)]` added in PR C. |
| `crates/ncp-mcp-server/src/cli.rs` | clap-derive CLI + `run()` function: validates `--trace-dir` per §12 (create if missing, fail on non-dir, canonicalize); loads each `--graph` via `RuntimeContext::load`; derives tool names; validates uniqueness; prints loaded-tool summary to stderr; exits 0. **NO MCP traffic.** |
| `crates/ncp-mcp-server/src/naming.rs` | Pure tool-name derivation per locked §3 rule + pure collision validator. **15 unit tests** covering spec example, dot/hyphen/underscore/digit preservation, slash/mixed/unicode replacement, all-disallowed → all-underscores (NOT error), empty-input error, max-len boundary tests, collision detection naming both paths. |
| `crates/ncp-mcp-server/src/send_sync_check.rs` | Compile-time bound assertions per §11. Two checks: `RuntimeContext: Send + Sync` (for `Arc<RuntimeContext>` in `spawn_blocking` closure) AND `anyhow::Result<ExecutionReport>: Send` (for `JoinHandle<R>` bound). Both verified at PR B build time. |
| `crates/ncp-mcp-server/tests/loading.rs` | **5 integration tests** against the built binary via `env!("CARGO_BIN_EXE_ncp-mcp-server")`: single-graph load, multi-graph load, collision detection, trace-dir-is-file rejection, trace-dir-non-existent-is-created. **Every test asserts stdout EMPTY** (catches §7 logging-discipline violations early, before PR C's process-level JSON-RPC test). |

## PR B exit gates (all 5 pass)

```text
1. cargo build -p ncp-mcp-server --locked
   Finished `dev` profile [unoptimized + debuginfo] target(s)
   exit 0

2. cargo clippy -p ncp-mcp-server --locked --all-targets -- -D warnings
   Finished `dev` profile [unoptimized + debuginfo] target(s)
   exit 0  (after fixing one doc_overindented_list_items warning in send_sync_check.rs)

3. cargo test -p ncp-mcp-server --locked
   running 15 tests (naming.rs)
   test result: ok. 15 passed; 0 failed
   running 5 tests (tests/loading.rs)
   test result: ok. 5 passed; 0 failed
   Total: 20/20 passing

4. RUSTDOCFLAGS="-D warnings" cargo doc -p ncp-mcp-server --no-deps --all-features
   Documenting ncp-mcp-server v0.1.0
   Finished `dev` profile
   exit 0

5. cargo package -p ncp-mcp-server --list
   .cargo_vcs_info.json
   Cargo.lock         <-- present (confirms cargo install --locked will work)
   Cargo.toml
   Cargo.toml.orig
   LICENSE            <-- present (Apache §4(d))
   NOTICE             <-- present (Apache §4(d))
   README.md          <-- present (crates.io render)
   src/cli.rs
   src/lib.rs
   src/main.rs
   src/naming.rs
   src/send_sync_check.rs
   tests/loading.rs
```

## Design doc cross-references implemented

Each `docs/MCP_ADAPTER.md` decision relevant to PR B is implemented:

- **§2 Mapping** — multi-graph via repeated `--graph`; unique-name validation at startup via `naming::validate_no_collisions`.
- **§3 Tool-name derivation** — `naming::graph_id_to_tool_name` implements the locked rule. (Plus §3 doc wording fix.)
- **§7 Logging discipline** — summary line goes to `eprintln!` (stderr); tests assert stdout empty.
- **§8 Workspace structure** — separate crate at `crates/ncp-mcp-server/`.
- **§9 Dep pattern** — `ncp-runtime = { version = "0.3.6", path = "../../runtime" }`.
- **§11 Send+Sync verification** — `src/send_sync_check.rs` compile-time assertions; build succeeded so spawn_blocking path is locked for PR C.
- **§12 Trace-dir semantics** — `cli::validate_trace_dir` implements canonicalization + non-dir failure + create-if-missing per the locked rules.

NOT yet implemented (per plan):

- **§5 Tool call response shape** — needs MCP SDK (PR C).
- **§6 Error mapping truth table** — needs MCP SDK (PR C).
- **§10 SDK choice** — rmcp dep added in PR C.
- **§13 listChanged** — needs MCP SDK (PR C).
- **§17 No bare product names** — already respected in this PR's tracked content.

## What's NOT in this PR

- No MCP protocol traffic (`initialize` / `tools/list` / `tools/call` arrive in PR C).
- No `tokio` runtime; no `rmcp` dependency (added in PR C).
- No `#![deny(clippy::print_stdout)]` (added at both crate roots in PR C when stdout discipline becomes protocol-critical).
- No `src/server.rs` module (added in PR C).
- No `tests/mcp_protocol.rs` (added in PR C with in-process + process-level + concurrent-call tests).

## Test plan

- [ ] PR-time: all 10 required CI checks pass on Linux/macOS/Windows. The 20-test crate-local suite (15 unit + 5 integration) runs as part of the workspace-level `cargo test` matrix.
- [ ] Post-merge: clean local build via `cargo build -p ncp-mcp-server --locked` reproduces this PR's gates.
- [ ] PR C foundation: PR B's `cli.rs::run` becomes the pre-server graph-load step; PR C extends it to start the MCP server after the summary line.

## What comes next (PR C)

Adds `tokio` + `rmcp` deps; implements `src/server.rs` with `initialize` / `tools/list` / `tools/call` per §5–§7; adds `#![deny(clippy::print_stdout)]` to both crate roots; converts `cli::run` to async (or spawns tokio from sync); adds the concurrent-call integration test per §11.
