### PR TITLE
feat(mcp): implement MCP stdio server (PR 3A.2-C)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cc"
 version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +177,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -481,6 +488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +580,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -590,10 +604,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -616,6 +652,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -928,6 +965,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "ncp-classifier-stub"
 version = "0.1.0"
 dependencies = [
@@ -948,7 +996,10 @@ dependencies = [
  "anyhow",
  "clap",
  "ncp-runtime",
+ "rmcp",
  "serde_json",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -1001,6 +1052,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "petgraph"
@@ -1146,6 +1203,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1234,26 @@ dependencies = [
  "log",
  "rustc-hash",
  "smallvec",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1197,6 +1294,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,6 +1353,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1287,6 +1421,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "sized-chunks"
@@ -1405,6 +1549,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1625,37 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "typenum"

--- a/crates/ncp-mcp-server/Cargo.toml
+++ b/crates/ncp-mcp-server/Cargo.toml
@@ -35,7 +35,26 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 
-# Intentionally NO tokio and NO rmcp in PR B — those land in PR C when the
-# MCP protocol implementation arrives. PR B is plumbing only: graph loading,
-# tool-name derivation, uniqueness validation, trace-dir validation,
-# RuntimeContext Send+Sync compile assertion.
+# Pre-allocate trace IDs in the adapter so the SAME id is used for the
+# trace file path (`<trace-dir>/<trace_id>.jsonl`) and the MCP `tools/call`
+# response. `ExecutionReport` does not echo the runtime-generated trace id
+# back, so the adapter must own the value before execution. v4 (random)
+# suffices — no need for v7/timestamp ordering in v0.
+uuid = { version = "1", features = ["v4"] }
+
+# MCP stdio protocol layer (PR C). Per docs/MCP_ADAPTER.md §10 SDK verification:
+# rmcp v1.7 with default-features = false excludes compile-time tool macros so
+# runtime-loaded graphs can be exposed through a manual ServerHandler.
+rmcp = { version = "1.7", default-features = false, features = ["server", "transport-io"] }
+
+# Tokio runtime for the MCP server.
+# - rt-multi-thread: built manually in cli.rs; --check exits before this runtime
+#   is constructed.
+# - io-std: explicit because the stdio transport path depends on async stdio.
+tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
+
+[dev-dependencies]
+# Test-only async support. Keep macros out of the published runtime dependency
+# surface; tests can still use #[tokio::test]. `process` and `io-util` are
+# needed by tests/mcp_protocol.rs for subprocess spawning + stdio framing.
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process", "io-util"] }

--- a/crates/ncp-mcp-server/src/cli.rs
+++ b/crates/ncp-mcp-server/src/cli.rs
@@ -1,18 +1,25 @@
 //! CLI parsing, graph loading, and startup validation.
 //!
 //! This module is the entry-point logic that `src/main.rs` delegates to.
-//! In PR B, it loads each `--graph` manifest via `RuntimeContext::load`,
+//! In PR C, it loads each `--graph` manifest via `RuntimeContext::load`,
 //! derives MCP tool names via [`crate::naming`], validates uniqueness,
 //! validates the `--trace-dir` (if set), and prints a startup summary to
-//! stderr. **No MCP protocol traffic** — that arrives in PR C.
+//! stderr. Then:
+//!
+//! - If `--check` is set, exits `Ok(())` without constructing the tokio runtime.
+//! - Otherwise, builds a multi-thread tokio runtime and runs the MCP server
+//!   (see [`crate::server`]) until stdin closes (EOF).
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use ncp_runtime::RuntimeContext;
 
 use crate::naming;
+use crate::server::{self, StartupState, ToolEntry};
 
 /// `ncp-mcp-server` — MCP adapter for NCP graphs.
 #[derive(Parser, Debug)]
@@ -34,7 +41,7 @@ pub struct Cli {
     )]
     pub brick_dir: PathBuf,
 
-    /// Path to a YAML/JSON brick-map file (overrides --brick-dir for listed brick IDs).
+    /// Brick-map file; overrides --brick-dir for listed brick IDs.
     #[arg(long = "brick-map", value_name = "FILE")]
     pub brick_map: Option<PathBuf>,
 
@@ -42,6 +49,13 @@ pub struct Cli {
     /// If absent, traces are dropped (NullTrace).
     #[arg(long = "trace-dir", value_name = "DIR")]
     pub trace_dir: Option<PathBuf>,
+
+    /// Validate startup (load graphs, derive tool names, validate uniqueness
+    /// and trace-dir), print the summary, then exit 0 WITHOUT starting the
+    /// MCP server. Useful for config-validation in CI or before connecting
+    /// to an MCP host.
+    #[arg(long = "check")]
+    pub check: bool,
 }
 
 /// Validates `--trace-dir` per docs/MCP_ADAPTER.md §12:
@@ -71,24 +85,16 @@ pub fn validate_trace_dir(trace_dir: Option<&Path>) -> Result<Option<PathBuf>> {
     Ok(Some(canonical))
 }
 
-/// PR B startup flow: parse CLI, validate trace-dir, load each graph,
-/// derive tool names, validate uniqueness, print summary, exit 0.
+/// Loads all graphs, derives tool names, validates uniqueness, and assembles
+/// the `StartupState` that the MCP server will consume.
 ///
-/// PR C extends this to wire up the MCP server after the summary line.
-pub fn run() -> Result<()> {
-    let cli = Cli::parse();
+/// Per docs/MCP_ADAPTER.md §11, contexts are kept (wrapped in `Arc`) so they
+/// can be shared across `tokio::task::spawn_blocking` invocations during
+/// concurrent `tools/call` requests.
+fn load_startup_state(cli: &Cli) -> Result<StartupState> {
+    let trace_dir = validate_trace_dir(cli.trace_dir.as_deref())?;
 
-    // 1. Validate + canonicalize --trace-dir (per §12).
-    //    The canonicalized path is unused in PR B (no MCP traffic = no trace
-    //    writes). PR C will use it to construct per-call trace files.
-    let _trace_dir = validate_trace_dir(cli.trace_dir.as_deref())?;
-
-    // 2. Load each graph via RuntimeContext::load() — validates the graph
-    //    enough to construct a RuntimeContext (manifest parses, bricks resolve).
-    //    Collect (path, derived tool name) pairs.
-    //    PR B drops the loaded contexts after the summary; PR C will keep
-    //    them in a HashMap<ToolName, Arc<RuntimeContext>> for tools/call.
-    let mut pairs: Vec<(PathBuf, String)> = Vec::with_capacity(cli.graphs.len());
+    let mut staged: Vec<(String, ToolEntry)> = Vec::with_capacity(cli.graphs.len());
     for graph_path in &cli.graphs {
         let ctx = RuntimeContext::load(graph_path, &cli.brick_dir, cli.brick_map.as_deref())
             .with_context(|| format!("failed to load graph `{}`", graph_path.display()))?;
@@ -100,23 +106,68 @@ pub fn run() -> Result<()> {
             )
         })?;
 
-        pairs.push((graph_path.clone(), tool_name));
+        staged.push((
+            tool_name,
+            ToolEntry {
+                graph_path: graph_path.clone(),
+                graph_id: ctx.graph_id().to_string(),
+                graph_version: ctx.graph_version().to_string(),
+                context: Arc::new(ctx),
+            },
+        ));
     }
 
-    // 3. Validate no two graphs derive the same tool name.
+    // Validate uniqueness using (path, name) pairs derived from the staged
+    // entries. Cloning at startup is cheap; loads dominate the cost.
+    let pairs: Vec<(PathBuf, String)> = staged
+        .iter()
+        .map(|(name, entry)| (entry.graph_path.clone(), name.clone()))
+        .collect();
     naming::validate_no_collisions(&pairs)?;
 
-    // 4. Print loaded-tool summary to stderr.
-    //    Stdout is reserved for JSON-RPC protocol traffic (per §7); even in
-    //    PR B where no protocol is wired up, we follow the discipline.
-    let names: Vec<&str> = pairs.iter().map(|(_, n)| n.as_str()).collect();
+    // Move into the final HashMap (consumes staged).
+    let tools: HashMap<String, ToolEntry> = staged.into_iter().collect();
+    Ok(StartupState { tools, trace_dir })
+}
+
+/// Prints the loaded-tool summary line to stderr.
+///
+/// Stdout is reserved for JSON-RPC protocol traffic (per §7); summary goes to
+/// stderr in both `--check` mode and server mode so MCP-host log capture sees
+/// the same startup signal regardless. Tool names are sorted for deterministic
+/// output (HashMap iteration order is otherwise non-deterministic).
+fn print_summary(state: &StartupState) {
+    let mut names: Vec<&str> = state.tools.keys().map(String::as_str).collect();
+    names.sort();
     eprintln!(
         "loaded {} graph(s) as MCP tools: {}",
         names.len(),
         names.join(", ")
     );
+}
 
-    // 5. PR B exits cleanly here. PR C replaces this point with the MCP
-    //    server loop (initialize / tools/list / tools/call over stdio).
-    Ok(())
+/// PR C startup flow: parse CLI, load + validate, print summary; then either
+/// exit (--check) or build tokio runtime and run the MCP server.
+///
+/// `--check` returns BEFORE tokio runtime construction (per docs/MCP_ADAPTER.md
+/// §11 refinement) so:
+/// - `--check` mode has zero async setup overhead.
+/// - `--check` mode preserves the PR B invariant that stdout stays empty.
+pub fn run() -> Result<()> {
+    let cli = Cli::parse();
+    let startup = load_startup_state(&cli)?;
+    print_summary(&startup);
+
+    if cli.check {
+        return Ok(());
+    }
+
+    // No `.enable_all()` / `.enable_io()`: v0 is stdio-only and does not use
+    // tokio timers or the reactor-backed I/O driver. `tokio::io::stdin/stdout`
+    // works with the `io-std` feature; PR C keeps runtime drivers minimal.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .build()
+        .context("failed to build tokio runtime")?;
+
+    rt.block_on(server::run(startup))
 }

--- a/crates/ncp-mcp-server/src/lib.rs
+++ b/crates/ncp-mcp-server/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::print_stdout)]
+
 //! # ncp-mcp-server
 //!
 //! A stdio [Model Context Protocol] adapter for [NCP] — exposes auditable
@@ -46,5 +48,8 @@ pub mod cli;
 
 #[doc(hidden)]
 pub mod naming;
+
+#[doc(hidden)]
+pub mod server;
 
 mod send_sync_check;

--- a/crates/ncp-mcp-server/src/main.rs
+++ b/crates/ncp-mcp-server/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::print_stdout)]
+
 //! Binary entrypoint for `ncp-mcp-server`.
 //!
 //! Thin wrapper that delegates to `ncp_mcp_server::cli::run`. All

--- a/crates/ncp-mcp-server/src/server.rs
+++ b/crates/ncp-mcp-server/src/server.rs
@@ -1,0 +1,457 @@
+//! MCP stdio server wiring (PR C).
+//!
+//! Implements the manual `ServerHandler` for the NCP MCP adapter against
+//! the runtime-loaded graphs assembled by `crate::cli`. Three RPC methods
+//! are exposed:
+//!
+//! - `initialize` — default rmcp impl returns `self.get_info()` (per
+//!   rmcp 1.7 `server_handler_methods!` macro). We only override
+//!   `get_info` to advertise the `tools` capability with
+//!   `listChanged: false` (per docs/MCP_ADAPTER.md §13: v0's tool list
+//!   is static post-startup).
+//! - `tools/list` — enumerates one `Tool` per loaded graph; input
+//!   schema is the v0 `{"type":"object"}` object (per §4); descriptions
+//!   embed `graph_id` + `graph_version`.
+//! - `tools/call` — dispatches by tool name, runs the graph via
+//!   `tokio::task::spawn_blocking` (which owns ALL blocking work
+//!   including trace-writer construction), and builds a
+//!   `CallToolResult` per §5 (`structuredContent` + text content
+//!   mirror; rolled-up `result_type`; `isError` per §6 Class A).
+//!
+//! Error mapping (per docs/MCP_ADAPTER.md §6):
+//!
+//! - **Class A (graph outcomes):** Success / LowConfidence / Failure
+//!   (including the adapter-synthesized empty-terminals Failure per
+//!   §5) all return `Ok(CallToolResult)` with `isError` per §5
+//!   truth table.
+//! - **Class B (protocol / infra):** unknown tool name,
+//!   trace-writer construction failure pre-execution,
+//!   `spawn_blocking` JoinError, `execute()` returning `Err` →
+//!   returned as `McpError` (JSON-RPC error response).
+//! - **Class C (mid-execution trace I/O failure):** NOT detectable
+//!   in v0 because `TraceSink::emit_*` returns `()`. See §6 Class C
+//!   for the honest contract and the runtime API change that would
+//!   unlock detection.
+//!
+//! Sync/async bridging (per §11): the rmcp tokio handler offloads
+//! each `tools/call` to `spawn_blocking`, which is sound because
+//! PR B's `send_sync_check` module verified `RuntimeContext: Send +
+//! Sync` at compile time. ALL blocking work — trace writer file
+//! creation, `emit_runtime_info`, and `execute()` itself — happens
+//! inside the blocking closure. The async handler thread only
+//! computes paths, clones `Arc`s, and forwards the JoinHandle.
+//!
+//! **rmcp model-struct construction discipline:** rmcp `#[non_exhaustive]`
+//! model structs are built via `Default::default()` + field mutation because
+//! struct literals are not available outside rmcp. Exhaustive rmcp model
+//! structs use struct literals so clippy can enforce complete construction.
+//! In this file, `CallToolResult`, `InitializeResult` (= `ServerInfo`), and
+//! `ServerCapabilities` use Default + mutation; `ToolsCapability` is
+//! exhaustive in rmcp 1.7 and is constructed with a literal.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use ncp_runtime::result::BrickResult;
+use ncp_runtime::trace::{JsonlTraceWriter, NullTrace, TraceSink};
+use ncp_runtime::{
+    mapping, ExecuteHooks, ExecuteOptions, ExecutionReport, RuntimeContext,
+    TerminalResult as RuntimeTerminalResult,
+};
+use rmcp::handler::server::ServerHandler;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, Content, ErrorData as McpError, Implementation,
+    JsonObject, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+    ToolsCapability,
+};
+use rmcp::service::{RequestContext, RoleServer};
+use rmcp::transport::stdio;
+use rmcp::ServiceExt;
+use serde_json::{json, Map, Value};
+use uuid::Uuid;
+
+// ── Shared startup state (consumed by cli.rs) ───────────────────────
+
+/// One MCP tool, backed by a loaded NCP graph.
+///
+/// Constructed by `crate::cli` during startup. The `context` is wrapped
+/// in `Arc` so each `tools/call` can clone a cheap handle and move it
+/// into a `tokio::task::spawn_blocking` closure without serializing
+/// concurrent calls on a single shared owner.
+pub struct ToolEntry {
+    pub graph_path: PathBuf,
+    pub graph_id: String,
+    pub graph_version: String,
+    pub context: Arc<RuntimeContext>,
+}
+
+/// Server startup state, assembled by `crate::cli::run` and consumed
+/// by `run`.
+///
+/// `trace_dir` is the canonicalized directory path (per §12) or `None`
+/// when `--trace-dir` was absent.
+pub struct StartupState {
+    pub tools: HashMap<String, ToolEntry>,
+    pub trace_dir: Option<PathBuf>,
+}
+
+// ── Tokio entrypoint ────────────────────────────────────────────────
+
+/// Build the rmcp server, attach it to stdio, and run until the peer
+/// closes the connection.
+///
+/// `cli.rs` calls this inside `rt.block_on(...)` after the startup
+/// summary has been written to stderr. Returning `Ok(())` here means
+/// the MCP peer (or stdin EOF) cleanly ended the session.
+pub async fn run(state: StartupState) -> Result<()> {
+    let server = McpServer {
+        tools: Arc::new(state.tools),
+        trace_dir: state.trace_dir.map(Arc::new),
+    };
+
+    let running = server
+        .serve(stdio())
+        .await
+        .context("failed to start MCP stdio service")?;
+
+    let _quit_reason = running
+        .waiting()
+        .await
+        .context("MCP service loop ended unexpectedly")?;
+    Ok(())
+}
+
+// ── ServerHandler implementation ────────────────────────────────────
+
+/// `ServerHandler` impl for the NCP MCP adapter.
+///
+/// All fields are `Arc`-wrapped because `ServerHandler` requires
+/// `Send + Sync + 'static` and rmcp's `serve()` may internally clone /
+/// share the handler across tasks. Read-only after construction.
+#[derive(Clone)]
+struct McpServer {
+    tools: Arc<HashMap<String, ToolEntry>>,
+    trace_dir: Option<Arc<PathBuf>>,
+}
+
+impl ServerHandler for McpServer {
+    fn get_info(&self) -> ServerInfo {
+        // Build ServerInfo via Default + field mutation because
+        // `InitializeResult` (= `ServerInfo`) is `#[non_exhaustive]`
+        // in rmcp 1.7. Struct-literal construction would fail to
+        // compile from outside the rmcp crate.
+        //
+        // We explicitly do NOT call `Implementation::from_build_env()`
+        // because that resolves `env!()` against the rmcp crate's
+        // manifest (yielding `name: "rmcp"`). Instead we call
+        // `Implementation::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))`
+        // so the macros expand against THIS crate, yielding the
+        // correct `name: "ncp-mcp-server"`.
+        let mut caps = ServerCapabilities::default();
+        // Per §13: v0's tool list is static post-startup; we do NOT
+        // emit notifications/tools/list_changed, so the capability
+        // flag is explicitly `false`.
+        //
+        // `ToolsCapability` is exhaustive in rmcp 1.7, unlike
+        // `ServerCapabilities`, `ServerInfo`, and `CallToolResult`. Use a
+        // literal here so clippy can enforce complete construction; use
+        // Default + mutation only for non-exhaustive types.
+        caps.tools = Some(ToolsCapability {
+            list_changed: Some(false),
+        });
+
+        let mut info = ServerInfo::default();
+        info.capabilities = caps;
+        info.server_info = Implementation::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        info.instructions = None;
+        info
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        // Sort tool names deterministically — HashMap iteration order
+        // is otherwise non-deterministic and clients tend to display
+        // tools in the order returned.
+        let mut names: Vec<&String> = self.tools.keys().collect();
+        names.sort();
+
+        let tools: Vec<Tool> = names
+            .into_iter()
+            .map(|name| {
+                let entry = &self.tools[name];
+                Tool::new(
+                    name.clone(),
+                    format!(
+                        "NCP graph {} ({}). Object-shaped arguments are passed verbatim as the graph root input.",
+                        entry.graph_id, entry.graph_version
+                    ),
+                    Arc::new(object_input_schema()),
+                )
+            })
+            .collect();
+
+        Ok(ListToolsResult::with_all_items(tools))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        // ── Class B: unknown tool name ─────────────────────────────
+        let tool_name = request.name.as_ref();
+        let entry = self
+            .tools
+            .get(tool_name)
+            .ok_or_else(|| McpError::invalid_params(format!("unknown tool: {tool_name}"), None))?;
+
+        // Pre-allocate trace_id so the SAME id appears in both the
+        // trace file path and the structured response (per §12).
+        let trace_id = Uuid::new_v4().to_string();
+
+        // Compute trace path ON the async handler thread (cheap —
+        // PathBuf::join, no I/O). The actual file create happens
+        // INSIDE spawn_blocking so the blocking syscall stays off
+        // the tokio runtime threads.
+        let trace_path: Option<PathBuf> = self
+            .trace_dir
+            .as_ref()
+            .map(|dir| dir.join(format!("{trace_id}.jsonl")));
+
+        // MCP `arguments` is `Option<JsonObject>`. v0 (per §4) accepts
+        // any object and passes it verbatim as the graph root input.
+        // Absent arguments become `{}` for consistency.
+        let arguments_value: Value = request
+            .arguments
+            .map(Value::Object)
+            .unwrap_or_else(|| Value::Object(Map::new()));
+
+        let ctx = Arc::clone(&entry.context);
+        let trace_id_for_blocking = trace_id.clone();
+        let trace_path_for_blocking = trace_path.clone();
+
+        // ALL blocking work runs here: trace-writer construction
+        // (filesystem create), `emit_runtime_info` (writes one JSONL
+        // record), and `execute()` itself. The closure returns
+        // `anyhow::Result<ExecutionReport>` so writer-construction
+        // failure and `execute()` failure flow through the same
+        // Class B error path below.
+        let execution_result = tokio::task::spawn_blocking(move || -> Result<ExecutionReport> {
+            let mut tracer: Box<dyn TraceSink + Send> = match &trace_path_for_blocking {
+                Some(path) => Box::new(JsonlTraceWriter::file(path).with_context(|| {
+                    format!("trace writer construction failed for `{}`", path.display())
+                })?),
+                None => Box::new(NullTrace),
+            };
+
+            ctx.emit_runtime_info(tracer.as_mut());
+
+            let mut hooks = ExecuteHooks::default();
+            let opts = ExecuteOptions {
+                trace_id: Some(trace_id_for_blocking),
+                ..Default::default()
+            };
+
+            ctx.execute(&arguments_value, tracer.as_mut(), &mut hooks, &opts)
+        })
+        .await;
+
+        // ── Class B: spawn_blocking join failure (panic / cancellation) ──
+        let report = execution_result
+            .map_err(|join_err| {
+                McpError::internal_error(
+                    format!("graph execution task panicked or was cancelled: {join_err}"),
+                    None,
+                )
+            })?
+            // ── Class B: closure returned Err — either trace-writer
+            // construction failed OR `execute()` returned a
+            // runtime-level error (missing brick key, queue overflow,
+            // broken edge mapping). Both surface as JSON-RPC errors.
+            // "tool call execution failed" because this path covers
+            // both pre-execution (writer construction) and execution
+            // failures; "graph execution failed" would be misleading
+            // when the graph never ran.
+            .map_err(|exec_err| {
+                McpError::internal_error(format!("tool call execution failed: {exec_err:#}"), None)
+            })?;
+
+        // ── Class A: build the §5 response shape from the report ──
+        Ok(build_call_tool_result(
+            &report,
+            &trace_id,
+            trace_path.as_deref(),
+        ))
+    }
+}
+
+// ── Response shape builders (per §5) ────────────────────────────────
+
+/// Build the v0 tool input schema literal: `{ "type": "object" }`.
+///
+/// Per §4: v0 declares an object-shaped input; the MCP `arguments`
+/// object is passed verbatim as the graph root input. No per-graph
+/// schema declaration in v0.
+fn object_input_schema() -> JsonObject {
+    let mut m = Map::new();
+    m.insert("type".to_string(), Value::String("object".to_string()));
+    m
+}
+
+/// Build a `CallToolResult` from an `ExecutionReport` per §5.
+///
+/// Three branches:
+///
+/// 1. **Empty terminals (adapter-synthesized Failure per §5):**
+///    `execute()` returned `Ok` but with no terminal results. Adapter
+///    refuses to report Success because no graph output was produced.
+///    Synthesizes a top-level `NO_TERMINAL_RESULTS` adapter error.
+/// 2. **Non-empty, all Success:** rolled-up `result_type: "Success"`,
+///    `isError: false`.
+/// 3. **Non-empty, any Failure / LowConfidence:** rolled-up
+///    `result_type` per §5 table, `isError: true`.
+///
+/// The text-content array mirrors `structuredContent` as a single
+/// JSON-stringified entry (per §5 "text content mirror").
+///
+/// Constructed via `Default` + field mutation because `CallToolResult`
+/// is `#[non_exhaustive]` in rmcp 1.7.
+fn build_call_tool_result(
+    report: &ExecutionReport,
+    trace_id: &str,
+    trace_path: Option<&Path>,
+) -> CallToolResult {
+    let terminal_results_json: Vec<Value> = report
+        .terminals
+        .iter()
+        .map(terminal_result_to_json)
+        .collect();
+
+    let trace_path_value = trace_path
+        .map(|p| Value::String(p.display().to_string()))
+        .unwrap_or(Value::Null);
+
+    let (structured, is_error) = if report.terminals.is_empty() {
+        // Adapter-synthesized Failure: see §5 "Empty terminal results".
+        let structured = json!({
+            "result_type": "Failure",
+            "output_json": Value::Null,
+            "trace_id": trace_id,
+            "trace_path": trace_path_value,
+            "terminal_results": terminal_results_json,
+            "error": {
+                "class": "NO_TERMINAL_RESULTS",
+                "message": "Graph execution completed without terminal results",
+            },
+        });
+        (structured, true)
+    } else {
+        let (rolled_up_type, is_error) = rollup_status(report);
+        let output_json = derive_output_json(&report.terminals, &terminal_results_json);
+        let structured = json!({
+            "result_type": rolled_up_type,
+            "output_json": output_json,
+            "trace_id": trace_id,
+            "trace_path": trace_path_value,
+            "terminal_results": terminal_results_json,
+        });
+        (structured, is_error)
+    };
+
+    let text_mirror = structured.to_string();
+
+    let mut result = CallToolResult::default();
+    result.content = vec![Content::text(text_mirror)];
+    result.structured_content = Some(structured);
+    result.is_error = Some(is_error);
+    result
+}
+
+/// Roll terminal-level result types up to a single top-level value
+/// (per §5 "top-level result_type" table). The boolean is `isError`.
+///
+/// **Precondition:** `report.terminals` is non-empty. The empty case
+/// is handled by `build_call_tool_result` before this function is
+/// called (it represents an adapter-synthesized Failure with
+/// dedicated shape, not a rollup of zero terminals).
+fn rollup_status(report: &ExecutionReport) -> (&'static str, bool) {
+    let mut any_failure = false;
+    let mut any_low_conf = false;
+    for t in &report.terminals {
+        match &t.result {
+            BrickResult::Failure { .. } => any_failure = true,
+            BrickResult::LowConfidence { .. } => any_low_conf = true,
+            BrickResult::Success { .. } => {}
+        }
+    }
+    if any_failure {
+        ("Failure", true)
+    } else if any_low_conf {
+        ("LowConfidence", true)
+    } else {
+        ("Success", false)
+    }
+}
+
+/// Convert one runtime `TerminalResult` to its §5 JSON representation:
+/// `node_id`, `brick_id`, `step`, `result_type`, optional `output`
+/// (Success/LowConfidence only), optional `error`
+/// (LowConfidence/Failure only).
+///
+/// `err.error_class` and `err.message` are accessed by reference to
+/// avoid moving out of `&ErrorObject` (those fields are `String`,
+/// non-`Copy`). `json!` accepts `&T: Serialize` for object values.
+/// `step` uses `json!(t.step)` to stay type-agnostic if the runtime
+/// ever changes the field's integer type.
+fn terminal_result_to_json(t: &RuntimeTerminalResult) -> Value {
+    let mut obj = Map::new();
+    obj.insert("node_id".to_string(), Value::String(t.node_id.clone()));
+    obj.insert("brick_id".to_string(), Value::String(t.brick_id.clone()));
+    obj.insert("step".to_string(), json!(t.step));
+    obj.insert(
+        "result_type".to_string(),
+        Value::String(t.result.result_type().to_string()),
+    );
+    if let Some(output) = t.result.output() {
+        obj.insert("output".to_string(), mapping::cbor_to_json(output));
+    }
+    if let Some(err) = t.result.error() {
+        obj.insert(
+            "error".to_string(),
+            json!({
+                "class": &err.error_class,
+                "message": &err.message,
+            }),
+        );
+    }
+    Value::Object(obj)
+}
+
+/// Derive the `output_json` convenience field per §5 truth table:
+///
+/// | Terminal results | `output_json` |
+/// |---|---|
+/// | exactly one Success or LowConfidence terminal | that terminal's output JSON |
+/// | multiple terminal results (any mix) | `{ "terminal_results": [...] }` |
+/// | Failure-only (no usable output across terminals) | `null` |
+///
+/// **Precondition:** `terminals` is non-empty. The empty case is
+/// handled by the dedicated adapter-synthesized Failure branch in
+/// `build_call_tool_result`.
+fn derive_output_json(terminals: &[RuntimeTerminalResult], all_json: &[Value]) -> Value {
+    if terminals.len() == 1 {
+        match terminals[0].result.output() {
+            Some(output) => mapping::cbor_to_json(output),
+            None => Value::Null,
+        }
+    } else if terminals.iter().all(|t| t.result.output().is_none()) {
+        Value::Null
+    } else {
+        json!({ "terminal_results": all_json })
+    }
+}

--- a/crates/ncp-mcp-server/tests/loading.rs
+++ b/crates/ncp-mcp-server/tests/loading.rs
@@ -13,10 +13,19 @@
 //! - `--trace-dir` pointing at a non-existent directory creates it,
 //!   exit 0, stdout empty.
 //!
-//! Every test asserts stdout is EMPTY because PR B has no MCP protocol
-//! traffic yet — the binary should write only to stderr. This catches
-//! stdout pollution early, before PR C's full process-level JSON-RPC
-//! test (per docs/MCP_ADAPTER.md §7 logging discipline).
+//! Every test passes `--check` so the binary validates startup (loads
+//! graphs, derives tool names, validates uniqueness, validates
+//! `--trace-dir`) and exits BEFORE constructing the tokio runtime or
+//! starting the MCP stdio service. This keeps the tests focused on the
+//! startup-validation surface PR B added, without depending on the MCP
+//! protocol implementation that lands in PR C.
+//!
+//! Every test also asserts stdout is EMPTY. In `--check` mode there is
+//! no MCP traffic, so the binary writes only to stderr; this catches
+//! stdout pollution from the load/validate code paths early. The full
+//! process-level JSON-RPC stdout-discipline test lives in
+//! `tests/mcp_protocol.rs` (PR C file 8) and exercises the running
+//! server.
 //!
 //! All tests construct paths relative to `CARGO_MANIFEST_DIR` so they work
 //! regardless of the test runner's CWD.
@@ -95,6 +104,7 @@ fn assert_stderr_contains(output: &Output, needle: &str) {
 #[test]
 fn one_graph_loads_and_prints_tool_name() {
     let output = run_binary(&[
+        "--check",
         "--graph",
         echo_pipeline_graph().to_str().unwrap(),
         "--brick-dir",
@@ -119,6 +129,7 @@ fn one_graph_loads_and_prints_tool_name() {
 #[test]
 fn two_distinct_graphs_load_both_names_printed() {
     let output = run_binary(&[
+        "--check",
         "--graph",
         echo_pipeline_graph().to_str().unwrap(),
         "--graph",
@@ -151,6 +162,7 @@ fn two_colliding_graphs_fail_with_clear_error() {
     let path_str = path.to_str().unwrap();
 
     let output = run_binary(&[
+        "--check",
         "--graph",
         path_str,
         "--graph",
@@ -180,6 +192,7 @@ fn trace_dir_pointing_at_existing_file_errors() {
     std::fs::write(&target, b"hello").expect("failed to create test file");
 
     let output = run_binary(&[
+        "--check",
         "--graph",
         echo_pipeline_graph().to_str().unwrap(),
         "--brick-dir",
@@ -211,6 +224,7 @@ fn trace_dir_pointing_at_non_existent_path_is_created() {
     assert!(!target.exists(), "test setup: target should not exist yet");
 
     let output = run_binary(&[
+        "--check",
         "--graph",
         echo_pipeline_graph().to_str().unwrap(),
         "--brick-dir",

--- a/crates/ncp-mcp-server/tests/mcp_protocol.rs
+++ b/crates/ncp-mcp-server/tests/mcp_protocol.rs
@@ -1,0 +1,538 @@
+//! End-to-end MCP protocol tests for `ncp-mcp-server` (PR C scope).
+//!
+//! Every test in this file drives the built binary as a subprocess via
+//! Cargo's `CARGO_BIN_EXE_ncp-mcp-server` env var (avoids hardcoded
+//! `target/debug/...` paths that break on Windows `.exe` suffix or
+//! release profile). The subprocess speaks JSON-RPC 2.0 over stdio —
+//! these tests exercise the wire shape directly, without depending on
+//! rmcp's client-side abstractions.
+//!
+//! This is the "real protocol guard" per docs/MCP_ADAPTER.md §7 and
+//! per the PR C plan. It catches:
+//!
+//! - **Stdout pollution:** every stdout line read via `read_frame()`
+//!   must parse as JSON AND have `jsonrpc == "2.0"`. Anything that
+//!   leaks to stdout from logging, panics, or third-party
+//!   instrumentation fails the assertion.
+//! - **Wire-shape regressions:** `tools/list` + `tools/call` responses
+//!   are validated against the §5 structured shape.
+//! - **Class A vs Class B error mapping:** unknown tool name MUST
+//!   return JSON-RPC error (Class B), NOT a successful response with
+//!   `isError: true`. Malformed JSON-RPC MUST return an error
+//!   response. Per §6 these distinctions are the most easily
+//!   conflated in MCP integrations.
+//! - **Concurrent dispatch correctness:** 4 in-flight `tools/call`s
+//!   all complete with distinct ids + distinct trace_ids, and all 4
+//!   trace files end up on disk. Behavioral concurrency assertion —
+//!   no wall-clock timing, robust against CI noise.
+//!
+//! All subprocess interactions are wrapped in `tokio::time::timeout`
+//! with a 10s deadline. On test failure (assertion or timeout),
+//! `Server`'s `Drop` impl calls `start_kill()` so no orphan processes
+//! survive in CI. The runtime is `#[tokio::test(flavor = "multi_thread")]`
+//! so that subprocess I/O and timeout polling can run in parallel
+//! reliably even when a test happens to run alone.
+//!
+//! **stderr discipline:** the child's stderr is routed to `Stdio::null()`
+//! at OS level. We intentionally do NOT pipe stderr because we never
+//! drain it — a noisy failure could fill the pipe buffer (64KB on
+//! Linux) and deadlock the subprocess. Discarding via the null device
+//! preserves the "stderr content is irrelevant" stance from the plan
+//! while removing the deadlock hazard.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::time::timeout;
+
+const RPC_TIMEOUT: Duration = Duration::from_secs(10);
+
+// ── Workspace path helpers (mirror tests/loading.rs) ────────────────
+
+fn binary() -> &'static str {
+    env!("CARGO_BIN_EXE_ncp-mcp-server")
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("CARGO_MANIFEST_DIR has at least two parents")
+        .to_path_buf()
+}
+
+fn echo_pipeline_graph() -> PathBuf {
+    workspace_root().join("examples/graphs/echo-pipeline/graph.yaml")
+}
+
+fn brick_dir() -> PathBuf {
+    workspace_root().join("examples/bricks")
+}
+
+/// Unique temp dir per test invocation, including a process-global
+/// atomic counter so parallel `cargo test` invocations within the same
+/// binary don't collide.
+fn unique_temp_dir(test_name: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let p = std::env::temp_dir().join(format!(
+        "ncp-mcp-server-mcp-test-{}-{}-{}",
+        test_name,
+        std::process::id(),
+        n,
+    ));
+    let _ = std::fs::remove_dir_all(&p);
+    p
+}
+
+// ── Subprocess driver ───────────────────────────────────────────────
+
+/// A running `ncp-mcp-server` subprocess with piped stdin/stdout and
+/// `Stdio::null()` on stderr. Dropping the `Server` kills the child
+/// (non-blocking `start_kill`) so test panics or assertion failures
+/// never leave orphan processes.
+struct Server {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl Server {
+    async fn spawn(trace_dir: Option<&Path>) -> Self {
+        let mut cmd = Command::new(binary());
+        cmd.arg("--graph")
+            .arg(echo_pipeline_graph())
+            .arg("--brick-dir")
+            .arg(brick_dir());
+        if let Some(td) = trace_dir {
+            cmd.arg("--trace-dir").arg(td);
+        }
+        // stderr goes to /dev/null (or NUL on Windows). Piping without
+        // draining could deadlock the child if its stderr buffer
+        // fills (64KB on Linux). The plan allows stderr to contain
+        // arbitrary output; discarding satisfies that.
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+
+        let mut child = cmd
+            .spawn()
+            .expect("failed to spawn ncp-mcp-server subprocess");
+        let stdin = child.stdin.take().expect("piped stdin");
+        let stdout = child.stdout.take().expect("piped stdout");
+        Server {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+            next_id: 1,
+        }
+    }
+
+    fn next_id(&mut self) -> i64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+
+    /// Write one JSON-RPC frame (one line + LF) to stdin. JSON-RPC
+    /// over stdio uses LF-delimited framing regardless of host OS.
+    async fn send_frame(&mut self, frame: &Value) {
+        let line = format!("{}\n", frame);
+        timeout(RPC_TIMEOUT, self.stdin.write_all(line.as_bytes()))
+            .await
+            .expect("timed out writing to subprocess stdin")
+            .expect("write to subprocess stdin failed");
+        timeout(RPC_TIMEOUT, self.stdin.flush())
+            .await
+            .expect("timed out flushing subprocess stdin")
+            .expect("flush of subprocess stdin failed");
+    }
+
+    /// Write raw bytes verbatim to stdin (for malformed-input tests
+    /// that intentionally do not produce a serialized `Value`).
+    async fn send_raw(&mut self, bytes: &[u8]) {
+        timeout(RPC_TIMEOUT, self.stdin.write_all(bytes))
+            .await
+            .expect("timed out writing raw bytes to subprocess stdin")
+            .expect("raw write to subprocess stdin failed");
+        timeout(RPC_TIMEOUT, self.stdin.flush())
+            .await
+            .expect("timed out flushing subprocess stdin")
+            .expect("flush of subprocess stdin failed");
+    }
+
+    /// Read one line from stdout and parse it as JSON. Asserts the
+    /// line is well-formed JSON-RPC 2.0. This is the §7 stdout-
+    /// discipline guard.
+    async fn read_frame(&mut self) -> Value {
+        let mut line = String::new();
+        let bytes_read = timeout(RPC_TIMEOUT, self.stdout.read_line(&mut line))
+            .await
+            .expect("timed out reading subprocess stdout")
+            .expect("read from subprocess stdout failed");
+        assert!(
+            bytes_read > 0,
+            "subprocess closed stdout before sending a frame"
+        );
+        let parsed: Value = serde_json::from_str(line.trim_end())
+            .unwrap_or_else(|e| panic!("stdout line is not valid JSON: {e}\n  line: {line:?}"));
+        assert_eq!(
+            parsed.get("jsonrpc"),
+            Some(&json!("2.0")),
+            "stdout line is not JSON-RPC 2.0: {parsed}",
+        );
+        parsed
+    }
+
+    /// Perform the `initialize` request + `notifications/initialized`
+    /// notification handshake. Returns the initialize response.
+    async fn initialize(&mut self) -> Value {
+        let id = self.next_id();
+        let init = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "ncp-mcp-server-test", "version": "0.1.0"},
+            },
+        });
+        self.send_frame(&init).await;
+        let response = self.read_frame().await;
+        assert_eq!(
+            response.get("id"),
+            Some(&json!(id)),
+            "initialize response id mismatch: {response}"
+        );
+
+        let initialized = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+        });
+        self.send_frame(&initialized).await;
+        response
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        // start_kill is non-blocking and safe in Drop. This is a fallback
+        // cleanup path for panics/timeouts; tests do not rely on graceful
+        // shutdown here.
+        let _ = self.child.start_kill();
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+/// `initialize` succeeds with the `tools` capability advertised and
+/// `tools/list` enumerates exactly one tool (the echo-pipeline graph).
+#[tokio::test(flavor = "multi_thread")]
+async fn initialize_and_tools_list() {
+    let mut server = Server::spawn(None).await;
+    let init_response = server.initialize().await;
+
+    let result = init_response.get("result").expect("initialize result");
+    assert!(
+        result["capabilities"]["tools"].is_object(),
+        "expected tools capability in initialize response: {result}"
+    );
+    // §13 contract: listChanged is explicitly false (not omitted).
+    assert_eq!(
+        result["capabilities"]["tools"]["listChanged"],
+        json!(false),
+        "listChanged must be false per §13: {result}"
+    );
+
+    // tools/list
+    let id = server.next_id();
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/list",
+        "params": {},
+    });
+    server.send_frame(&req).await;
+    let resp = server.read_frame().await;
+    assert_eq!(resp.get("id"), Some(&json!(id)));
+    assert!(resp.get("error").is_none(), "tools/list errored: {resp}");
+
+    let tools = resp["result"]["tools"]
+        .as_array()
+        .expect("tools/list result must contain tools array");
+    assert_eq!(tools.len(), 1, "expected exactly one loaded tool");
+    assert_eq!(
+        tools[0]["name"], "org.ncp-examples.echo-pipeline",
+        "expected derived tool name to match graph_id"
+    );
+    // §4: input schema is `{"type":"object"}`.
+    assert_eq!(tools[0]["inputSchema"]["type"], json!("object"));
+}
+
+/// `tools/call` against the echo graph returns a Class A successful
+/// response with `isError: false` and the §5 structuredContent shape.
+#[tokio::test(flavor = "multi_thread")]
+async fn tools_call_returns_class_a_success() {
+    let mut server = Server::spawn(None).await;
+    server.initialize().await;
+
+    let id = server.next_id();
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": {
+            "name": "org.ncp-examples.echo-pipeline",
+            "arguments": {"hello": "world"},
+        },
+    });
+    server.send_frame(&req).await;
+    let resp = server.read_frame().await;
+
+    assert_eq!(resp.get("id"), Some(&json!(id)));
+    assert!(
+        resp.get("error").is_none(),
+        "Class A: tools/call must NOT be a JSON-RPC error: {resp}"
+    );
+
+    let result = resp.get("result").expect("tools/call result");
+    assert_eq!(
+        result["isError"],
+        json!(false),
+        "Success rollup must set isError: false"
+    );
+
+    let sc = result.get("structuredContent").expect("structuredContent");
+    assert_eq!(sc["result_type"], json!("Success"));
+    assert!(sc["trace_id"].is_string(), "trace_id must be present");
+    assert_eq!(
+        sc["trace_path"],
+        Value::Null,
+        "trace_path must be null when --trace-dir is not set"
+    );
+    assert!(
+        sc["terminal_results"].is_array(),
+        "terminal_results must be present"
+    );
+    assert!(
+        !sc["terminal_results"].as_array().unwrap().is_empty(),
+        "echo graph must produce at least one terminal result"
+    );
+
+    // §5 text-content mirror: content[0] is a text item whose body is
+    // the JSON serialization of structuredContent.
+    let content = result["content"].as_array().expect("content array");
+    assert_eq!(content.len(), 1);
+    assert_eq!(content[0]["type"], json!("text"));
+    let mirror: Value = serde_json::from_str(content[0]["text"].as_str().expect("text string"))
+        .expect("content[0].text must be valid JSON");
+    assert_eq!(
+        &mirror, sc,
+        "text content must be the JSON serialization of structuredContent"
+    );
+}
+
+/// `tools/call` with an unknown tool name returns a Class B JSON-RPC
+/// error response — NOT a successful result with `isError: true`. Per
+/// §6, conflating these is the most common MCP integration bug.
+#[tokio::test(flavor = "multi_thread")]
+async fn unknown_tool_returns_jsonrpc_error() {
+    let mut server = Server::spawn(None).await;
+    server.initialize().await;
+
+    let id = server.next_id();
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": {
+            "name": "this.tool.does.not.exist",
+            "arguments": {},
+        },
+    });
+    server.send_frame(&req).await;
+    let resp = server.read_frame().await;
+
+    assert_eq!(resp.get("id"), Some(&json!(id)));
+    assert!(
+        resp.get("error").is_some(),
+        "Class B: unknown tool must return JSON-RPC error, got: {resp}"
+    );
+    assert!(
+        resp.get("result").is_none(),
+        "Class B: JSON-RPC error response must NOT have 'result', got: {resp}"
+    );
+}
+
+/// Malformed JSON-RPC input returns a JSON-RPC error response. We do
+/// NOT overfit the exact error message — the assertion is purely on
+/// the response shape: `error` present, `result` absent.
+#[tokio::test(flavor = "multi_thread")]
+async fn malformed_input_returns_jsonrpc_error() {
+    let mut server = Server::spawn(None).await;
+    server.initialize().await;
+
+    // Syntactically invalid JSON-RPC frame. LF-terminated so the
+    // server's line reader actually attempts to parse it.
+    server.send_raw(b"{ this is definitely not json }\n").await;
+
+    let resp = server.read_frame().await;
+    assert!(
+        resp.get("error").is_some(),
+        "malformed input must return JSON-RPC error, got: {resp}"
+    );
+    assert!(
+        resp.get("result").is_none(),
+        "JSON-RPC error response must NOT have 'result', got: {resp}"
+    );
+}
+
+/// 4 in-flight `tools/call` requests against the echo graph all
+/// complete with distinct ids, distinct trace_ids, all `isError:
+/// false`, and all 4 trace files end up on disk. Behavioral
+/// concurrency assertion — no wall-clock timing.
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_calls_complete_independently() {
+    const N: usize = 4;
+
+    let trace_dir = unique_temp_dir("concurrent");
+    let mut server = Server::spawn(Some(&trace_dir)).await;
+    server.initialize().await;
+
+    // Send all N requests without reading any responses in between.
+    let mut sent_ids: Vec<i64> = Vec::with_capacity(N);
+    for i in 0..N {
+        let id = server.next_id();
+        sent_ids.push(id);
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": {
+                "name": "org.ncp-examples.echo-pipeline",
+                "arguments": {"call_number": i},
+            },
+        });
+        server.send_frame(&req).await;
+    }
+
+    // Read N responses. Order is unconstrained — correlate by id.
+    let mut responses: Vec<Value> = Vec::with_capacity(N);
+    for _ in 0..N {
+        responses.push(server.read_frame().await);
+    }
+
+    // All N sent ids appear in the N responses, each exactly once.
+    let response_ids: HashSet<i64> = responses
+        .iter()
+        .filter_map(|r| r.get("id").and_then(Value::as_i64))
+        .collect();
+    let sent_id_set: HashSet<i64> = sent_ids.iter().copied().collect();
+    assert_eq!(
+        response_ids.len(),
+        N,
+        "expected {N} distinct response ids, got: {response_ids:?}"
+    );
+    assert_eq!(
+        response_ids, sent_id_set,
+        "response ids do not match sent ids"
+    );
+
+    // All N responses are Class A successes with isError: false.
+    for r in &responses {
+        assert!(
+            r.get("error").is_none(),
+            "concurrent call returned JSON-RPC error: {r}"
+        );
+        assert_eq!(
+            r["result"]["isError"],
+            json!(false),
+            "concurrent call had isError: true: {r}"
+        );
+    }
+
+    // All N trace_ids are distinct.
+    let trace_ids: Vec<String> = responses
+        .iter()
+        .map(|r| {
+            r["result"]["structuredContent"]["trace_id"]
+                .as_str()
+                .expect("structuredContent.trace_id must be a string")
+                .to_string()
+        })
+        .collect();
+    let trace_id_set: HashSet<&String> = trace_ids.iter().collect();
+    assert_eq!(
+        trace_id_set.len(),
+        N,
+        "expected {N} distinct trace_ids, got: {trace_ids:?}"
+    );
+
+    // All N trace files exist on disk and are non-empty.
+    for tid in &trace_ids {
+        let path = trace_dir.join(format!("{tid}.jsonl"));
+        assert!(
+            path.exists(),
+            "trace file missing for trace_id {tid}: {}",
+            path.display()
+        );
+        let meta = std::fs::metadata(&path).expect("metadata on trace file");
+        assert!(
+            meta.len() > 0,
+            "trace file is empty for trace_id {tid}: {}",
+            path.display()
+        );
+    }
+
+    // Each response's structuredContent.trace_path must MATCH the
+    // expected `<trace-dir>/<trace_id>.jsonl` for that response's
+    // trace_id. Canonicalize both sides before comparing because the
+    // server-side trace-dir is canonicalized at startup (per §12); on
+    // Windows the response path carries a `\\?\` UNC prefix and on
+    // macOS `/tmp` resolves to `/private/tmp`. Raw `PathBuf`
+    // comparison would give false negatives on those platforms.
+    for r in &responses {
+        let sc = &r["result"]["structuredContent"];
+
+        let trace_id = sc["trace_id"].as_str().expect("trace_id must be a string");
+
+        let trace_path_str = sc["trace_path"]
+            .as_str()
+            .expect("trace_path must be a string when --trace-dir is set");
+
+        let actual = PathBuf::from(trace_path_str);
+        assert!(
+            actual.exists(),
+            "structuredContent.trace_path does not exist on disk: {}",
+            actual.display()
+        );
+
+        let expected = trace_dir.join(format!("{trace_id}.jsonl"));
+        assert!(
+            expected.exists(),
+            "expected trace file does not exist on disk: {}",
+            expected.display()
+        );
+
+        let actual_canonical = std::fs::canonicalize(&actual)
+            .expect("actual trace_path must canonicalize after existence check");
+        let expected_canonical = std::fs::canonicalize(&expected)
+            .expect("expected trace file must canonicalize after existence check");
+
+        assert_eq!(
+            actual_canonical, expected_canonical,
+            "structuredContent.trace_path must match <trace-dir>/<trace_id>.jsonl"
+        );
+    }
+
+    drop(server); // explicit; otherwise Drop kills the child anyway.
+    let _ = std::fs::remove_dir_all(&trace_dir);
+}

--- a/docs/MCP_ADAPTER.md
+++ b/docs/MCP_ADAPTER.md
@@ -70,6 +70,7 @@ The adapter binary accepts these flags:
 | `--brick-dir <DIR>` | no | `examples/bricks` | Directory containing brick subdirectories. Passed through to `RuntimeContext::load()`. |
 | `--brick-map <FILE>` | no | — | Brick-map file; overrides `--brick-dir` for listed brick IDs. Passed through to `RuntimeContext::load()`. |
 | `--trace-dir <DIR>` | no | — | Directory for per-call trace files. See §12 for full semantics. If absent, traces are dropped (`NullTrace`). |
+| `--check` | no | `false` | Validate startup, print the loaded-tool summary to stderr, then exit without constructing the tokio runtime or starting the MCP server. |
 
 `--brick-dir` and `--brick-map` mirror the existing `ncp` runtime CLI semantics — adopters who already use the runtime CLI know these flags.
 
@@ -227,6 +228,34 @@ is set, the server canonicalizes the trace directory at startup
 (creating it if missing); `trace_path` is therefore an absolute path
 to `<canonical-trace-dir>/<trace_id>.jsonl` when emitted. See §11 for
 the full trace-dir lifecycle.
+
+### Empty terminal results — adapter-synthesized Failure
+
+If `RuntimeContext::execute()` returns `Ok(ExecutionReport)` with an
+empty `terminals` vector, the adapter MUST NOT report Success.
+Reporting Success would tell the MCP host that the tool completed
+normally when in fact no graph output was produced. The current
+runtime should not emit empty terminals under normal operation
+(every loop exit path either pushes a terminal or returns `Err`),
+but the adapter defends against it as a forward-compatibility
+invariant.
+
+In this case the adapter returns:
+
+| Field | Value |
+|---|---|
+| `structuredContent.result_type` | `"Failure"` |
+| `structuredContent.output_json` | `null` |
+| `structuredContent.terminal_results` | `[]` |
+| `structuredContent.error.class` | `"NO_TERMINAL_RESULTS"` |
+| `structuredContent.error.message` | `"Graph execution completed without terminal results"` |
+| `isError` | `true` |
+
+This is the only case where a top-level `error` object appears
+inside `structuredContent`. Per-terminal errors live in
+`terminal_results[i].error` (per the Failure-only example below);
+the top-level `error` is reserved for adapter-level signaling when
+the per-terminal channel has nothing to say.
 
 ### Example — Success (single terminal, common case)
 
@@ -395,49 +424,53 @@ the graph could produce a result. These get JSON-RPC error responses
 | Graph-load failure at startup | startup failure (process exits non-zero); never reaches RPC layer |
 | Trace-setup failure BEFORE graph execution begins | JSON-RPC error on the tools/call |
 
-### Class C — Hybrid case: trace-write failure mid-execution (PR C implementation requirement)
+### Class C — Trace I/O failure: v0 limitation (honest contract)
 
-A specific edge case: the graph executed and produced a valid
-`ExecutionReport`, but writing the trace file failed mid-way (disk
-full, permission revoked, etc).
+A specific edge case: trace I/O fails (disk full, permission
+revoked, path race, etc). What v0 detects depends on *when* the
+failure happens.
 
-**Implementation requirement for PR C:** implement a trace sink that
-records trace-write failures *without* aborting graph execution after
-execution has started. If the graph returns a valid result but trace
-writing failed, the adapter:
+**Detected (becomes a JSON-RPC error per Class B above):**
+- `--trace-dir` validation failure at startup (not a directory,
+  cannot create) → startup failure; never reaches the RPC layer.
+- Trace-writer construction failure for a specific `tools/call`
+  (e.g. the adapter cannot create/open the intended
+  `<trace_id>.jsonl` path using the runtime's public trace-writer
+  API) → JSON-RPC error on that call, BEFORE the graph runs.
 
-- Returns a SUCCESSFUL `tools/call` response containing the valid
-  graph result.
-- Sets `isError: true`.
-- Adds a `trace_error` field to `structuredContent` describing what
-  went wrong.
+**NOT detected in v0 (silent — graph result returns as if tracing
+succeeded):**
+- Mid-execution trace-write failure. The `TraceSink::emit_*` methods
+  in the current runtime API return `()`, not `Result<(), _>`. A
+  write that fails after the first record has been emitted cannot
+  be surfaced to the adapter without a runtime API change. The
+  adapter has no signal to attach a trace error to the response.
+- Trace-file close/flush failure at the end of execution. Same
+  reason: the sink has no fallible-completion contract in v0.
 
-```json
-{
-  "structuredContent": {
-    "result_type": "Success",
-    "output_json": { ... },
-    "trace_id": "...",
-    "trace_path": "/path/to/incomplete.jsonl",
-    "terminal_results": [ ... ],
-    "trace_error": {
-      "class": "TRACE_WRITE_FAILED",
-      "message": "..."
-    }
-  },
-  "isError": true
-}
-```
+**v0 contract for `tools/call` responses:** the `trace_path` field
+in `structuredContent` points at the file the adapter *intended* to
+write. If the file exists and is complete, great. If it is
+truncated, missing records, or was never written past the open
+syscall, the adapter cannot tell. Adopters who need strong trace
+durability guarantees should treat `trace_path` as best-effort in
+v0 and verify the file contents out-of-band.
 
-This is the only case where `result_type: "Success"` ships alongside
-`isError: true`. The `trace_error` field's presence is the
-disambiguator.
+**Future fix (out of scope for v0, requires runtime API change):**
+one of:
+- Make `TraceSink::emit_*` fallible (returns `Result<(), TraceError>`),
+  and define how the runtime propagates per-record write failures
+  without aborting execution.
+- Introduce a writer-backed trace sink whose drop/flush surfaces
+  accumulated I/O errors to the embedder via a side-channel
+  (`Arc<Mutex<Option<TraceError>>>` or equivalent).
+- Either path lets a future adapter version re-introduce a trace
+  error field and `isError: true` for the mid-execution case
+  described in earlier drafts of this design doc.
 
-**If the existing `TraceSink` implementation propagates errors out of
-`execute()`,** PR C wraps it in a non-failing adapter shim that
-captures the trace error into a side channel and resumes the
-execution flow. That shim is the PR C implementation deliverable for
-this case.
+Until that runtime API arrives, the adapter does NOT manufacture
+synthetic trace errors, and `result_type: "Success"` always ships
+with `isError: false`.
 
 ---
 
@@ -843,18 +876,20 @@ both complete, no result loss).
 
 For each `tools/call` invocation:
 - Allocate a new `trace_id` (UUID v4) at the start of the call.
-- Open `<canonical-trace-dir>/<trace_id>.jsonl` with
-  exclusive-create semantics (`OpenOptions::new().write(true).create_new(true)`)
-  where the OS supports it. Filename collision is statistically
-  impossible (UUID v4) but `create_new` makes any collision a hard
-  failure rather than silent overwrite.
+- Construct a runtime trace writer for
+  `<canonical-trace-dir>/<trace_id>.jsonl` using the runtime's public
+  trace-writer API. Filename collision is statistically negligible
+  because `trace_id` is UUID v4. v0 does not promise atomic
+  exclusive-create semantics unless the runtime trace-writer API itself
+  provides them.
 - Stream JSONL trace records as the graph executes (same format as
   the existing `runtime/src/trace.rs` machinery — the adapter wraps
   it, doesn't reinvent).
 - On success: `trace_path` field in the response is the absolute
   path to the file.
-- On write failure mid-execution: see §6 Class C (PR C builds the
-  non-failing trace shim).
+- On write failure mid-execution: not detectable by the adapter in
+  v0 — see §6 Class C for the honest limitation and the runtime
+  API change required to fix it.
 
 ### Why per-call files (not a single shared file)
 


### PR DESCRIPTION
## Summary

- rmcp v1.7-backed stdio server: `initialize`, `tools/list`, `tools/call` for loaded NCP graphs; one graph = one MCP tool per docs/MCP_ADAPTER.md §2.
- §5 response shape: `structuredContent` + text-content mirror; rolled-up `result_type` with `isError` per §6 Class A truth table; adapter-synthesized `NO_TERMINAL_RESULTS` Failure guards the empty-terminals edge case.
- §6 error mapping: Class A graph outcomes return `Ok(CallToolResult)`; Class B (unknown tool, trace-writer construction failure, JoinError, `execute()` Err) return JSON-RPC errors; Class C (mid-execution trace I/O failure) documented as v0 limitation since `TraceSink::emit_*` returns `()`.
- All blocking work (writer construction, `emit_runtime_info`, `execute`) lives inside `tokio::task::spawn_blocking`; async handler threads only compute paths, clone `Arc`s, and forward the JoinHandle.
- 5 process-level subprocess tests including 4-way concurrent dispatch correctness (distinct ids + trace_ids + trace files, no wall-clock timing).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build -p ncp-mcp-server --locked` clean
- [x] `cargo clippy -p ncp-mcp-server --all-targets -- -D warnings` clean
- [x] `cargo test -p ncp-mcp-server --locked` — 25/25 (15 naming unit + 5 loading integration + 5 mcp_protocol integration)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p ncp-mcp-server --no-deps --all-features` clean
- [x] `cargo test -p ncp-runtime --all-targets --locked` no regression — 5/5
- [x] MCP_ADAPTER.md stale-token grep (`trace_error|exclusive-create|create_new|non-failing trace shim`) — only the intentional negative-promise survivor at §12
- [ ] Required CI: Linux Rust job + WASM brick job pass
- [ ] Manual smoke against `examples/graphs/echo-pipeline/graph.yaml` (deferred to PR D — `examples/mcp/echo-pipeline-mcp-smoke.md`)