### PR TITLE
feat(mcp): example dir + CI smoke job (PR 3A.2-D)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,6 +78,30 @@ jobs:
       - run: cargo test -p ncp-runtime --all-targets --locked
 
   # ──────────────────────────────────────────────────────────────────────
+  # MCP SMOKE JOB: build the ncp-mcp-server release binary and drive it
+  # through a real MCP stdio dialog against the echo-pipeline example
+  # graph. Validates the adopter path end-to-end with a stdlib-only
+  # Python driver. See examples/mcp/ci_smoke.py for the assertion list
+  # and docs/MCP_ADAPTER.md §5 for the response-shape contract.
+  #
+  # This job is NOT yet bound to branch protection. Adding it to the
+  # required-check set is a separate ruleset edit per
+  # docs/BRANCH_PROTECTION.md "Adding new required checks" section.
+  # ──────────────────────────────────────────────────────────────────────
+  mcp-smoke:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+      - uses: Swatinem/rust-cache@v2
+        with: { key: mcp-smoke }
+      - run: cargo build -p ncp-mcp-server --release --locked
+      - run: python3 examples/mcp/ci_smoke.py
+
+  # ──────────────────────────────────────────────────────────────────────
   # WASM JOB: build & lint the brick crates for wasm32-unknown-unknown.
   # Brick crates are LIBRARY targets that can only compile to WASM.
   # If you find yourself moving these into the host matrix, STOP — they

--- a/docs/MCP_ADAPTER.md
+++ b/docs/MCP_ADAPTER.md
@@ -76,6 +76,15 @@ The adapter binary accepts these flags:
 
 The MCP protocol layer (`initialize` / `tools/list` / `tools/call`) takes no CLI flags; transport is implicit (stdio).
 
+### Adopter resources
+
+| Resource | Purpose |
+|---|---|
+| [MCP example README](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/examples/mcp/README.md) | Adopter-facing landing page for the MCP example directory. |
+| [Generic host config snippet](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/examples/mcp/desktop-host-config.example.json) | MCP-host config snippet to substitute absolute paths into. |
+| [Manual echo-pipeline smoke test](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/examples/mcp/echo-pipeline-mcp-smoke.md) | Manual stdio dialog walk-through for verifying a build. |
+| [CI smoke script](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/examples/mcp/ci_smoke.py) | Automated stdlib-only Python driver that the `mcp-smoke` CI job runs; usable locally. |
+
 ---
 
 ## 3. Tool-name derivation rule

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -1,0 +1,117 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 Fabio Marcello Salvadori
+-->
+
+# `examples/mcp/` — MCP adapter examples
+
+This directory shows how to drop an [NCP] graph into an
+MCP-compatible host as a callable tool, using
+[`ncp-mcp-server`](https://github.com/madeinplutofabio/neural-computation-protocol/tree/main/crates/ncp-mcp-server)
+— the stdio Model Context Protocol adapter for NCP.
+
+**One graph = one MCP tool.** Configure your MCP-compatible host's
+tool config to launch `ncp-mcp-server --graph <your-graph>.yaml`,
+and that graph becomes a callable tool with no glue code.
+
+[NCP]: https://github.com/madeinplutofabio/neural-computation-protocol
+
+---
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| `README.md` | This file. |
+| [Generic host config snippet](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/examples/mcp/desktop-host-config.example.json) | MCP-compatible-host config snippet adopters customize with their own absolute paths. |
+| [Manual echo-pipeline smoke test](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/examples/mcp/echo-pipeline-mcp-smoke.md) | Manual stdio dialog walk-through against the bundled `echo-pipeline` graph. Confirm the adapter works on your host before wiring it into a real MCP-compatible host. |
+| [CI smoke script](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/examples/mcp/ci_smoke.py) | The CI smoke script the `mcp-smoke` job runs (Python stdlib only). Adopters can run it locally to verify a build end-to-end. |
+
+---
+
+## Quick start (source install)
+
+> `ncp-mcp-server` is not yet on crates.io (Phase 3A.2-E ships
+> `cargo install ncp-mcp-server --locked`). Until then, build it
+> from source in a workspace checkout.
+
+```bash
+# 1. Clone the workspace
+git clone https://github.com/madeinplutofabio/neural-computation-protocol.git
+cd neural-computation-protocol
+
+# 2. Build the adapter binary (release profile)
+cargo build -p ncp-mcp-server --release --locked
+
+# 3. The binary is now at:
+ls target/release/ncp-mcp-server      # macOS / Linux
+ls target/release/ncp-mcp-server.exe  # Windows
+```
+
+---
+
+## Wiring into an MCP-compatible host
+
+Many MCP-compatible desktop hosts and MCP-compatible CLI hosts read a
+shared-shape JSON config that lists external MCP servers. Copy
+[the generic host config snippet](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/examples/mcp/desktop-host-config.example.json)
+into your host's config file (location varies by host — consult your
+host's docs), and substitute:
+
+- `command`: the **absolute** path to the `ncp-mcp-server` binary you
+  built above.
+- `args[1]`: the **absolute** path to your graph manifest.
+- `args[3]`: the **absolute** path to a directory containing your
+  bricks.
+
+The example config wires the bundled `org.ncp-examples.echo-pipeline`
+graph; replace the paths to use your own graph.
+
+> Paths in MCP-host configs MUST be absolute. Host working directories
+> at launch time vary across hosts; relative paths will silently
+> resolve against whatever the host happens to be in.
+
+---
+
+## Verifying the adapter manually
+
+Before wiring into a real MCP-compatible host, confirm the adapter
+runs and the JSON-RPC dialog works on your machine — see
+[the manual echo-pipeline smoke test](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/examples/mcp/echo-pipeline-mcp-smoke.md)
+for a step-by-step recipe.
+
+For an automated end-to-end check, run the same dialog as a Python
+script:
+
+```bash
+python3 examples/mcp/ci_smoke.py
+```
+
+Expected output: `SMOKE OK` to stdout, exit code `0`. The script is
+stdlib-only and runs on Linux/macOS/Windows.
+
+---
+
+## How the adapter behaves
+
+- **Stdio transport only** in v0; Streamable HTTP is a future phase.
+- **Stdout is reserved for JSON-RPC.** All adapter logs go to stderr
+  (MCP spec hard rule).
+- **One process per graph configuration** — each `--graph` flag adds
+  one tool. Multi-graph supported from day one via repeated `--graph`.
+- **Per-call traces** when `--trace-dir <dir>` is set; each
+  `tools/call` writes `<dir>/<trace_id>.jsonl`.
+
+Full design reference, including response-shape details and the
+Class A / Class B / Class C error mapping:
+[Full MCP adapter design doc](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/MCP_ADAPTER.md).
+
+---
+
+## Repo hygiene note
+
+Per the [Full MCP adapter design doc](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/MCP_ADAPTER.md)
+§17, this README intentionally avoids specific MCP-host product
+names. The config snippet shape is documented by the MCP specification
+and used in common by all MCP-compatible hosts the project is aware
+of.

--- a/examples/mcp/ci_smoke.py
+++ b/examples/mcp/ci_smoke.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""PR 3A.2-D — CI smoke for ncp-mcp-server.
+
+Drives the release-built `ncp-mcp-server` binary as a subprocess and
+verifies the end-to-end MCP stdio dialog against the echo-pipeline
+example graph. This script is what the `mcp-smoke` job in
+`.github/workflows/rust.yml` runs.
+
+Scope (per docs/MCP_ADAPTER.md): happy-path only. The full unit-of-PR-C
+protocol surface (unknown-tool errors, malformed-JSON errors,
+concurrent dispatch) is covered by `tests/mcp_protocol.rs`. This
+smoke verifies the adopter path: build → start → handshake →
+tools/list → tools/call → verify §5 response shape end-to-end.
+
+Dependencies: Python stdlib only — subprocess, json, sys, pathlib,
+tempfile, threading.
+
+Cross-platform: timeout enforcement uses threading.Timer (rather than
+signal.SIGALRM) so the script runs on Linux/macOS/Windows. CI pins
+ubuntu-24.04; adopters can run the same script locally on any
+platform after building the binary for their host.
+
+Timeout discipline: when the timer fires, it kills the subprocess.
+Both stdout reads (`read_line`) AND stdin writes (`send`) wrap the
+I/O in try/except + a `timeout_state["fired"]` check so a mid-write
+kill surfaces as `SMOKE FAIL: ... subprocess killed by timer`
+rather than an unhandled Python traceback.
+
+Subprocess stderr discipline: stderr is redirected to a temp file
+(NOT `subprocess.DEVNULL` or `subprocess.PIPE`). File redirection
+cannot fill a pipe buffer (kernel writes go straight to disk), so
+there is no deadlock hazard if the subprocess writes verbosely. On
+failure, `fail()` prints the last few KB of that log to stderr so
+CI logs carry diagnostics without a separate artifact-collection
+step. The temp file is unlinked on success and left on disk on
+failure for further inspection.
+
+Usage (from workspace root, after `cargo build -p ncp-mcp-server
+--release --locked`):
+
+    python3 examples/mcp/ci_smoke.py
+
+Exit codes:
+- 0 → all assertions passed; prints `SMOKE OK` to stdout.
+- 1 → an assertion failed or the script timed out; prints
+  `SMOKE FAIL: <reason>` to stderr, plus the tail of the subprocess
+  stderr log if one was captured. The subprocess is killed in a
+  `finally` block whether the script exits cleanly, asserts, or
+  times out.
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+# Overall script timeout. The timer kills the subprocess when it fires;
+# any pending readline() returns empty string and any pending write
+# raises BrokenPipeError/OSError, both of which read_line() / send()
+# turn into a clear timeout error. Sized to be generous against CI
+# cold-start jitter while still failing fast on real hangs.
+SCRIPT_TIMEOUT_SECS = 60
+
+# How much of the subprocess stderr log to dump on failure. 4 KiB is
+# generous for the v0 adapter's stderr (one startup summary line plus
+# any panic message); large enough to be useful, small enough to keep
+# CI log noise bounded.
+STDERR_TAIL_BYTES = 4096
+
+# Set by main() so fail() can include subprocess stderr diagnostics
+# in CI failure output. None when no log has been opened yet (e.g.
+# if `fail()` runs from the pre-flight path-existence checks).
+_STDERR_LOG_PATH: Path | None = None
+
+
+def fail(message: str) -> None:
+    """Print a smoke-failure message to stderr and exit 1.
+
+    If a subprocess stderr log was captured, dump the tail to stderr
+    to give CI logs and adopter terminals diagnostic context without
+    a separate artifact-collection step.
+    """
+    print(f"SMOKE FAIL: {message}", file=sys.stderr)
+    if _STDERR_LOG_PATH is not None and _STDERR_LOG_PATH.exists():
+        try:
+            data = _STDERR_LOG_PATH.read_text(errors="replace")
+            if data:
+                tail = data[-STDERR_TAIL_BYTES:]
+                print("--- subprocess stderr (tail) ---", file=sys.stderr)
+                print(tail.rstrip(), file=sys.stderr)
+                print("--- end stderr ---", file=sys.stderr)
+        except OSError:
+            # Log file unreadable; not worth a second-level error.
+            pass
+    sys.exit(1)
+
+
+def send(proc: subprocess.Popen, frame: dict, timeout_state: dict) -> None:
+    """Write one JSON-RPC frame (one line + LF) to the subprocess stdin.
+
+    Wraps write/flush in try/except so that if the timer kills the
+    subprocess mid-write (causing BrokenPipeError on Unix or OSError
+    on Windows when stdin closes), we surface a clean `SMOKE FAIL: ...`
+    line rather than letting an unhandled exception print a Python
+    traceback. The `timeout_state` container distinguishes "timer
+    fired" from a genuine I/O error so the failure message points at
+    the real cause.
+    """
+    line = json.dumps(frame) + "\n"
+    try:
+        proc.stdin.write(line)
+        proc.stdin.flush()
+    except (BrokenPipeError, OSError) as e:
+        if timeout_state["fired"]:
+            fail(
+                f"smoke script exceeded SCRIPT_TIMEOUT_SECS="
+                f"{SCRIPT_TIMEOUT_SECS} (subprocess killed by timer)"
+            )
+        fail(f"failed writing JSON-RPC frame to subprocess stdin: {e}")
+
+
+def read_line(proc: subprocess.Popen, timeout_state: dict) -> dict:
+    """Read one line from subprocess stdout and parse as JSON.
+
+    `timeout_state` is the shared mutable container the timer
+    populates; if `readline` returns empty AFTER the timer fired,
+    we surface a timeout failure rather than the generic
+    "subprocess closed stdout" message.
+    """
+    line = proc.stdout.readline()
+    if not line:
+        if timeout_state["fired"]:
+            fail(
+                f"smoke script exceeded SCRIPT_TIMEOUT_SECS="
+                f"{SCRIPT_TIMEOUT_SECS} (subprocess killed by timer)"
+            )
+        fail("subprocess closed stdout before sending a frame")
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError as e:
+        fail(f"stdout line is not valid JSON: {e}\n  line: {line!r}")
+
+
+def assert_jsonrpc(resp: dict, expected_id, context: str) -> None:
+    """Common JSON-RPC 2.0 envelope assertions."""
+    if resp.get("jsonrpc") != "2.0":
+        fail(f"{context}: response missing jsonrpc='2.0': {resp}")
+    if expected_id is not None and resp.get("id") != expected_id:
+        fail(f"{context}: response id mismatch (expected {expected_id}): {resp}")
+    if resp.get("error") is not None:
+        fail(f"{context}: response carried JSON-RPC error: {resp}")
+
+
+def run_smoke(proc: subprocess.Popen, timeout_state: dict) -> None:
+    """Execute the full happy-path dialog and assert against §5 shape."""
+    # ── initialize ────────────────────────────────────────────────
+    send(proc, {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {
+                "name": "ncp-mcp-server-ci-smoke",
+                "version": "0.1.0",
+            },
+        },
+    }, timeout_state)
+    init_resp = read_line(proc, timeout_state)
+    assert_jsonrpc(init_resp, expected_id=1, context="initialize")
+    result = init_resp.get("result")
+    if not isinstance(result, dict):
+        fail(f"initialize response has no result object: {init_resp}")
+    tools_cap = result.get("capabilities", {}).get("tools")
+    if not isinstance(tools_cap, dict):
+        fail(f"initialize result missing capabilities.tools: {init_resp}")
+    # §13: listChanged is false or absent (we emit it as false; absent
+    # is also acceptable for forward compatibility).
+    if tools_cap.get("listChanged", False) is not False:
+        fail(
+            f"capabilities.tools.listChanged must be false or absent per §13: "
+            f"{tools_cap}"
+        )
+
+    # ── notifications/initialized ─────────────────────────────────
+    send(proc, {
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized",
+    }, timeout_state)
+
+    # ── tools/list ────────────────────────────────────────────────
+    send(proc, {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list",
+        "params": {},
+    }, timeout_state)
+    list_resp = read_line(proc, timeout_state)
+    assert_jsonrpc(list_resp, expected_id=2, context="tools/list")
+    tools = list_resp.get("result", {}).get("tools", [])
+    if not isinstance(tools, list) or len(tools) == 0:
+        fail(f"tools/list returned empty tools array: {list_resp}")
+    tool_names = [t.get("name") for t in tools]
+    expected_name = "org.ncp-examples.echo-pipeline"
+    if expected_name not in tool_names:
+        fail(f"{expected_name!r} not in tools/list: {tool_names}")
+    echo_tool = next(t for t in tools if t.get("name") == expected_name)
+    schema_type = echo_tool.get("inputSchema", {}).get("type")
+    if schema_type != "object":
+        fail(
+            f"echo-pipeline inputSchema.type must be 'object' per §4, "
+            f"got {schema_type!r}: {echo_tool}"
+        )
+
+    # ── tools/call ────────────────────────────────────────────────
+    send(proc, {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {
+            "name": expected_name,
+            "arguments": {"smoke": "hello"},
+        },
+    }, timeout_state)
+    call_resp = read_line(proc, timeout_state)
+    assert_jsonrpc(call_resp, expected_id=3, context="tools/call")
+    call_result = call_resp.get("result")
+    if not isinstance(call_result, dict):
+        fail(f"tools/call response has no result object: {call_resp}")
+    if call_result.get("isError") is not False:
+        fail(
+            f"tools/call result.isError must be false on Class A Success: "
+            f"{call_result}"
+        )
+    sc = call_result.get("structuredContent")
+    if not isinstance(sc, dict):
+        fail(f"tools/call result missing structuredContent: {call_result}")
+    if sc.get("result_type") != "Success":
+        fail(f"structuredContent.result_type must be 'Success': {sc}")
+    if not isinstance(sc.get("trace_id"), str):
+        fail(f"structuredContent.trace_id must be a string: {sc}")
+    if not isinstance(sc.get("trace_path"), str):
+        fail(
+            f"structuredContent.trace_path must be a string when --trace-dir "
+            f"is set: {sc}"
+        )
+    if "output_json" not in sc:
+        fail(f"structuredContent.output_json must be present: {sc}")
+
+    # ── trace file exists + non-empty ─────────────────────────────
+    trace_path = Path(sc["trace_path"])
+    if not trace_path.exists():
+        fail(f"trace file does not exist on disk: {trace_path}")
+    if trace_path.stat().st_size == 0:
+        fail(f"trace file is empty: {trace_path}")
+
+    # ── text content mirror equals structuredContent ──────────────
+    content = call_result.get("content", [])
+    if not isinstance(content, list) or len(content) != 1:
+        fail(f"result.content must be a single-item array: {content}")
+    if content[0].get("type") != "text":
+        fail(f"content[0].type must be 'text': {content[0]}")
+    try:
+        mirror = json.loads(content[0]["text"])
+    except (json.JSONDecodeError, KeyError) as e:
+        fail(f"content[0].text must parse as JSON: {e}")
+    if mirror != sc:
+        fail(
+            "content[0].text must equal structuredContent "
+            "(JSON-serialized mirror per §5):\n"
+            f"  mirror:            {mirror}\n"
+            f"  structuredContent: {sc}"
+        )
+
+
+def main() -> None:
+    global _STDERR_LOG_PATH
+
+    workspace = Path(__file__).resolve().parent.parent.parent
+    binary = workspace / "target" / "release" / "ncp-mcp-server"
+    # Windows: cargo emits `ncp-mcp-server.exe`. Add the suffix so
+    # adopters running this script locally on Windows get a clean
+    # "release binary not found" message rather than a silent
+    # cross-host path mismatch.
+    if sys.platform == "win32":
+        binary = binary.with_suffix(".exe")
+    graph = workspace / "examples" / "graphs" / "echo-pipeline" / "graph.yaml"
+    brick_dir = workspace / "examples" / "bricks"
+
+    for path, label in [
+        (binary, "release binary"),
+        (graph, "echo-pipeline graph"),
+        (brick_dir, "brick dir"),
+    ]:
+        if not path.exists():
+            fail(
+                f"{label} not found: {path}\n"
+                f"  (did you run "
+                f"`cargo build -p ncp-mcp-server --release --locked` first?)"
+            )
+
+    trace_dir = Path(tempfile.mkdtemp(prefix="ncp-mcp-smoke-"))
+
+    # Open subprocess stderr log. File redirection avoids the pipe-
+    # buffer deadlock hazard of `subprocess.PIPE` (no buffer to fill;
+    # the kernel writes straight to disk) while still giving us
+    # diagnostics on CI failures via fail()'s tail dump. Opening in
+    # binary mode keeps the encoding decision in our hands at
+    # read-time via `read_text(errors="replace")`.
+    stderr_log = tempfile.NamedTemporaryFile(
+        mode="wb",
+        prefix="ncp-mcp-smoke-stderr-",
+        suffix=".log",
+        delete=False,
+    )
+    _STDERR_LOG_PATH = Path(stderr_log.name)
+
+    proc = subprocess.Popen(
+        [
+            str(binary),
+            "--graph",
+            str(graph),
+            "--brick-dir",
+            str(brick_dir),
+            "--trace-dir",
+            str(trace_dir),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=stderr_log,
+        text=True,  # text mode applies to stdin/stdout; stderr is binary file.
+        bufsize=1,  # line-buffered text I/O on stdin/stdout
+    )
+
+    # Cross-platform timeout. When the timer fires, the subprocess is
+    # killed; pending stdout reads then return empty string and pending
+    # stdin writes raise BrokenPipeError/OSError. Both code paths
+    # check this shared `timeout_state["fired"]` flag and surface a
+    # clear timeout failure message.
+    timeout_state = {"fired": False}
+
+    def on_timeout() -> None:
+        timeout_state["fired"] = True
+        try:
+            proc.kill()
+        except OSError:
+            # Already exited; nothing to kill.
+            pass
+
+    timer = threading.Timer(SCRIPT_TIMEOUT_SECS, on_timeout)
+    timer.daemon = True
+    timer.start()
+
+    success = False
+    try:
+        run_smoke(proc, timeout_state)
+        print("SMOKE OK")
+        success = True
+    finally:
+        timer.cancel()
+        if proc.stdin is not None:
+            try:
+                proc.stdin.close()
+            except (BrokenPipeError, OSError):
+                pass
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        try:
+            stderr_log.close()
+        except OSError:
+            pass
+        # On success, remove the stderr log to avoid tempfile sprawl
+        # in adopters' /tmp. On failure (including assertion exits via
+        # fail()), leave it on disk for further inspection beyond the
+        # tail we already printed.
+        if success and _STDERR_LOG_PATH is not None:
+            try:
+                _STDERR_LOG_PATH.unlink()
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mcp/desktop-host-config.example.json
+++ b/examples/mcp/desktop-host-config.example.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Generic MCP-compatible-host config snippet. Substitute absolute paths under `command` and `args` before pasting into your host's config file. See examples/mcp/README.md for full instructions.",
+  "mcpServers": {
+    "ncp-echo-pipeline": {
+      "command": "/absolute/path/to/ncp-mcp-server",
+      "args": [
+        "--graph",
+        "/absolute/path/to/neural-computation-protocol/examples/graphs/echo-pipeline/graph.yaml",
+        "--brick-dir",
+        "/absolute/path/to/neural-computation-protocol/examples/bricks"
+      ]
+    }
+  }
+}

--- a/examples/mcp/echo-pipeline-mcp-smoke.md
+++ b/examples/mcp/echo-pipeline-mcp-smoke.md
@@ -1,0 +1,246 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 Fabio Marcello Salvadori
+-->
+
+# Manual smoke test — `org.ncp-examples.echo-pipeline`
+
+End-to-end recipe for verifying that the built `ncp-mcp-server`
+binary speaks JSON-RPC correctly on your machine. Run this before
+wiring the adapter into a real MCP-compatible host.
+
+For an automated version of the same dialog, run
+[the CI smoke script](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/examples/mcp/ci_smoke.py)
+instead.
+
+---
+
+## 1. Build the binary
+
+From the workspace root:
+
+```bash
+cargo build -p ncp-mcp-server --release --locked
+```
+
+The binary lands at `target/release/ncp-mcp-server`
+(`target\release\ncp-mcp-server.exe` on Windows).
+
+---
+
+## 2. Launch the server against the echo graph
+
+In one terminal, with the workspace root as the working directory:
+
+```bash
+./target/release/ncp-mcp-server \
+  --graph examples/graphs/echo-pipeline/graph.yaml \
+  --brick-dir examples/bricks \
+  --trace-dir /tmp/ncp-mcp-smoke
+```
+
+The server writes a one-line summary to **stderr**:
+
+```
+loaded 1 graph(s) as MCP tools: org.ncp-examples.echo-pipeline
+```
+
+…and then blocks on stdin, waiting for JSON-RPC frames. **Stdout
+stays empty** until you send a request. That's the §7 stdout
+discipline at work.
+
+If you'd prefer to drive the server without typing JSON frames into a
+running process, see "Driving from the same terminal (Unix / macOS)"
+below.
+
+---
+
+## 3. Send the JSON-RPC dialog
+
+Each frame below is **one line of JSON terminated by `\n`**. The
+server reads one frame at a time from stdin.
+
+### 3.1 `initialize`
+
+Send:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"manual-smoke","version":"0.0.0"}}}
+```
+
+Expect on stdout (formatted for readability — the wire frame is one line):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2025-11-25",
+    "capabilities": {
+      "tools": { "listChanged": false }
+    },
+    "serverInfo": {
+      "name": "ncp-mcp-server",
+      "version": "0.1.0"
+    }
+  }
+}
+```
+
+Key fields to confirm:
+
+- `result.capabilities.tools` is present (the server advertises the
+  tools capability).
+- `result.capabilities.tools.listChanged` is `false` (per §13).
+- `result.serverInfo.name` is `ncp-mcp-server` (NOT `rmcp` — see §10
+  for the `Implementation::new(env!(...))` rationale).
+
+### 3.2 `notifications/initialized`
+
+Send (no response expected — this is a notification, not a request):
+
+```json
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+```
+
+### 3.3 `tools/list`
+
+Send:
+
+```json
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+```
+
+Expect:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "tools": [
+      {
+        "name": "org.ncp-examples.echo-pipeline",
+        "description": "NCP graph org.ncp-examples.echo-pipeline (<graph_version>). Object-shaped arguments are passed verbatim as the graph root input.",
+        "inputSchema": { "type": "object" }
+      }
+    ]
+  }
+}
+```
+
+Key fields to confirm:
+
+- Exactly one tool, named `org.ncp-examples.echo-pipeline` (per §3
+  derivation).
+- `inputSchema.type` is `"object"` (per §4 v0 schema).
+- `description` includes the graph_id and a `(<graph_version>)`
+  marker — the exact version string comes from the
+  `graph_version` field of the loaded manifest.
+
+### 3.4 `tools/call`
+
+Send (with any object-shaped arguments — the echo brick passes them
+through):
+
+```json
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"org.ncp-examples.echo-pipeline","arguments":{"hello":"world"}}}
+```
+
+Expect a Class A success response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "content": [
+      { "type": "text", "text": "<JSON serialization of structuredContent>" }
+    ],
+    "structuredContent": {
+      "result_type": "Success",
+      "output_json": { ... },
+      "trace_id": "<uuid>",
+      "trace_path": "/tmp/ncp-mcp-smoke/<trace_id>.jsonl",
+      "terminal_results": [ ... ]
+    },
+    "isError": false
+  }
+}
+```
+
+Key fields to confirm:
+
+- `result.isError` is `false` (Class A Success per §5/§6).
+- `result.structuredContent.result_type` is `"Success"`.
+- `result.structuredContent.trace_path` points at a real `.jsonl`
+  file inside the `--trace-dir`.
+- `result.structuredContent.terminal_results` is a non-empty array.
+  An empty array would trigger the adapter's defensive
+  `NO_TERMINAL_RESULTS` Failure path — the echo graph should always
+  produce at least one terminal.
+- `result.content[0].text` is a JSON string whose parsed value
+  equals `result.structuredContent` exactly (text mirror per §5).
+
+---
+
+## 4. Inspect the trace file
+
+The adapter wrote a trace for that call. Inspect it:
+
+```bash
+cat /tmp/ncp-mcp-smoke/<trace_id>.jsonl
+```
+
+Expected: one `runtime_info` record at the top, followed by one
+`invoke` record per brick step. Schema reference: the
+[NCP protocol spec](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/spec/ncp-v0.2.3.md).
+
+---
+
+## 5. Shut the server down
+
+Send `Ctrl+D` (Unix / macOS) or `Ctrl+Z` followed by `Enter`
+(Windows) to close stdin. The server exits cleanly when stdin
+reaches EOF.
+
+---
+
+## Driving from the same terminal (Unix / macOS)
+
+If your shell makes it inconvenient to type JSON frames into a
+running process, drive the server with a bash here-doc instead:
+
+```bash
+./target/release/ncp-mcp-server \
+  --graph examples/graphs/echo-pipeline/graph.yaml \
+  --brick-dir examples/bricks \
+  --trace-dir /tmp/ncp-mcp-smoke <<'EOF'
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"manual-smoke","version":"0.0.0"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"org.ncp-examples.echo-pipeline","arguments":{"hello":"world"}}}
+EOF
+```
+
+The server reads all four frames in one pass, emits three responses
+(the three requests; the notification has no response), then exits
+when it sees the here-doc's EOF.
+
+> **Windows note:** the bash here-doc syntax above is Unix / macOS
+> shell only. On Windows, either drive the server interactively
+> through the steps above OR run
+> [the CI smoke script](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/examples/mcp/ci_smoke.py)
+> for an automated cross-platform alternative.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `error: trace writer construction failed for <path>` | The `--trace-dir` points at a path that exists but isn't a writable directory. |
+| Server exits non-zero on startup with a "failed to load graph" message | The `--graph` argument points at a missing or malformed manifest, or `--brick-dir` doesn't contain the bricks the graph references. Re-run with `--check` to validate without starting the MCP server. |
+| `tools/call` returns a JSON-RPC error response (`error` present, `result` absent) | Class B — the tool name doesn't match the derived name in `tools/list`, or the request shape failed validation. Check the response's `error.message`. |
+| Response carries `result_type: "Failure"` and `isError: true` for a graph you expected to succeed | Read the per-terminal `error` objects in `structuredContent.terminal_results`. The graph itself returned a Failure terminal; the adapter is faithfully surfacing it (Class A). |
+| Output on stdout that isn't JSON-RPC | Bug — stdout is reserved per §7. File an issue with the offending line. |


### PR DESCRIPTION
## Summary

- New `examples/mcp/` directory: adopter-facing README, generic MCP-host config snippet, manual stdio smoke recipe, and a stdlib-only Python driver (`ci_smoke.py`) that drives the full happy-path dialog (initialize → tools/list → tools/call) against the bundled `echo-pipeline` graph.
- New `mcp-smoke` job in `.github/workflows/rust.yml` — parallel to fmt/clippy/test/wasm-build. Builds `ncp-mcp-server --release --locked` and runs `ci_smoke.py`. Visible on every PR but not yet bound to branch protection (separate ruleset edit per `docs/BRANCH_PROTECTION.md`).
- `docs/MCP_ADAPTER.md` §2 gains an "Adopter resources" subsection with descriptive links to the four new example files.
- Generic terminology per §17 (no specific MCP-host product names anywhere).

Adopter path now end-to-end: build the binary → paste the config snippet → drop a graph in. The CI smoke catches any regression in that path on every PR.

## Test plan

- [x] `cargo build -p ncp-mcp-server --release --locked` clean
- [x] `python3 examples/mcp/ci_smoke.py` → `SMOKE OK` locally
- [x] `desktop-host-config.example.json` parses as valid JSON
- [x] `docs/MCP_ADAPTER.md` stale-token grep (`trace_error|exclusive-create|create_new|non-failing trace shim`) — only the intentional `exclusive-create` negative-promise at §12
- [x] `examples/mcp/` stale-token grep — zero matches
- [x] Markdown sanity: every code fence closed, every `##` heading explicit, ellipsis placeholders (`{ ... }` / `[ ... ]`) per §5 style
- [ ] Existing required CI passes (fmt / clippy / test / wasm-build / DCO / validate / wasm-digest-check)
- [ ] New `mcp-smoke` job passes (currently optional; reaches required status via a separate `gh api -X PUT` ruleset edit per `docs/BRANCH_PROTECTION.md` "Adding new required checks")