### PR TITLE
chore(ci): require mcp-smoke status check

### DIFF
--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -18,7 +18,7 @@ update this file in the same PR.
 
 ---
 
-## Current required status checks (as of v0.3.3 release hygiene)
+## Current required status checks (as of Phase 3A.2-D — `mcp-smoke` added)
 
 Branch ruleset name: **Main Protection**
 Target: `refs/heads/main`
@@ -37,6 +37,7 @@ Required checks bound in `rules[].parameters.required_status_checks[].context`:
 | `test (ubuntu-24.04)` | `.github/workflows/rust.yml` — `test` job, matrix `os: ubuntu-24.04` |
 | `test (macos-14)` | `.github/workflows/rust.yml` — `test` job, matrix `os: macos-14` |
 | `test (windows-2022)` | `.github/workflows/rust.yml` — `test` job, matrix `os: windows-2022` |
+| `mcp-smoke` | `.github/workflows/rust.yml` — `mcp-smoke` job |
 | `wasm-build` | `.github/workflows/rust.yml` — `wasm-build` job |
 
 Other rules on the same ruleset:


### PR DESCRIPTION
## Summary

Binds the `mcp-smoke` job (added in PR 3A.2-D, #23) as a required check on the Main Protection ruleset. The adapter's end-to-end stdio smoke now gates every PR to main alongside `fmt`/`clippy`/`test`/`wasm-build`.

The live ruleset was updated via `gh api -X PUT` before this PR opened (per `docs/BRANCH_PROTECTION.md` "Adding new required checks"); this PR captures the doc-side change so the doc table matches live state.

## Verification

This PR is the first to be gated by the newly-required `mcp-smoke` check — if it passes here, the binding works correctly. Successful merge of this PR is the verification step the doc's procedure calls out ("Verify by opening any new PR... confirming the Checks panel shows all expected required checks gating merge").

## Test plan

- [x] Snapshot of pre-edit ruleset retained as `ruleset-before.json` (rollback panic-button per `docs/BRANCH_PROTECTION.md`)
- [x] `jq --slurpfile` merge with `unique_by(.context)` (idempotent)
- [x] `gh api -X PUT` against ruleset 15060933 — response confirms 11 required contexts including `mcp-smoke`
- [x] `gh api` read-back verifies live state
- [x] Doc table updated in this commit; "as of" header marker updated to "Phase 3A.2-D — `mcp-smoke` added"
- [ ] All 11 required checks pass on this PR (proves the binding works)