### PR TITLE
fix(mcp): enable tokio time driver for rmcp graceful shutdown

### DIFF
--- a/crates/ncp-mcp-server/Cargo.toml
+++ b/crates/ncp-mcp-server/Cargo.toml
@@ -51,7 +51,15 @@ rmcp = { version = "1.7", default-features = false, features = ["server", "trans
 # - rt-multi-thread: built manually in cli.rs; --check exits before this runtime
 #   is constructed.
 # - io-std: explicit because the stdio transport path depends on async stdio.
-tokio = { version = "1", features = ["rt-multi-thread", "io-std"] }
+# - time: rmcp's graceful-shutdown drain path (rmcp/src/service.rs:1061) uses
+#   `tokio::time::timeout` to bound the drain. Without the time driver enabled
+#   on the runtime, the server panics on stdin EOF. Caught by the Phase 3A.2-E
+#   real-host validation gate against the MCP Python SDK; CI smoke previously
+#   masked it because tests/mcp_protocol.rs kills the subprocess instead of
+#   closing stdin gracefully. Declared as a direct dep here so any future
+#   reader can see why the time driver is required, even though rmcp pulls
+#   the feature transitively.
+tokio = { version = "1", features = ["rt-multi-thread", "io-std", "time"] }
 
 [dev-dependencies]
 # Test-only async support. Keep macros out of the published runtime dependency

--- a/crates/ncp-mcp-server/src/cli.rs
+++ b/crates/ncp-mcp-server/src/cli.rs
@@ -162,10 +162,22 @@ pub fn run() -> Result<()> {
         return Ok(());
     }
 
-    // No `.enable_all()` / `.enable_io()`: v0 is stdio-only and does not use
-    // tokio timers or the reactor-backed I/O driver. `tokio::io::stdin/stdout`
-    // works with the `io-std` feature; PR C keeps runtime drivers minimal.
+    // Runtime drivers enabled (kept minimal, NOT `.enable_all()`):
+    // - `.enable_time()`: required by rmcp's graceful-shutdown drain
+    //   path (rmcp/src/service.rs:1061), which calls
+    //   `tokio::time::timeout` to bound the response drain on
+    //   `QuitReason::Closed` / `Cancelled`. Without it, the server
+    //   panics on every stdin EOF — caught by the Phase 3A.2-E
+    //   real-host validation gate against the MCP Python SDK; see
+    //   `tests/mcp_protocol.rs::graceful_shutdown_does_not_panic`
+    //   for the regression test.
+    // - I/O driver intentionally NOT enabled. `tokio::io::stdin`/
+    //   `stdout` (provided by the `io-std` feature) use
+    //   `spawn_blocking` internally rather than the reactor, so
+    //   `.enable_io()` would also pull in the `net` feature for no
+    //   gain. v0 is stdio-only.
     let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_time()
         .build()
         .context("failed to build tokio runtime")?;
 

--- a/crates/ncp-mcp-server/tests/mcp_protocol.rs
+++ b/crates/ncp-mcp-server/tests/mcp_protocol.rs
@@ -99,7 +99,13 @@ fn unique_temp_dir(test_name: &str) -> PathBuf {
 /// never leave orphan processes.
 struct Server {
     child: Child,
-    stdin: ChildStdin,
+    // `Option` so close_stdin() can `take()` the value and drop the
+    // pipe in place (closes stdin to the child, sending EOF). Required
+    // by graceful_shutdown_does_not_panic, which can't destructure
+    // Server because Server implements Drop. All non-graceful-shutdown
+    // tests still expect stdin to be Some — `send_frame`/`send_raw`
+    // unwrap with `.expect("stdin already closed")`.
+    stdin: Option<ChildStdin>,
     stdout: BufReader<ChildStdout>,
     next_id: i64,
 }
@@ -129,7 +135,7 @@ impl Server {
         let stdout = child.stdout.take().expect("piped stdout");
         Server {
             child,
-            stdin,
+            stdin: Some(stdin),
             stdout: BufReader::new(stdout),
             next_id: 1,
         }
@@ -145,11 +151,12 @@ impl Server {
     /// over stdio uses LF-delimited framing regardless of host OS.
     async fn send_frame(&mut self, frame: &Value) {
         let line = format!("{}\n", frame);
-        timeout(RPC_TIMEOUT, self.stdin.write_all(line.as_bytes()))
+        let stdin = self.stdin.as_mut().expect("stdin already closed");
+        timeout(RPC_TIMEOUT, stdin.write_all(line.as_bytes()))
             .await
             .expect("timed out writing to subprocess stdin")
             .expect("write to subprocess stdin failed");
-        timeout(RPC_TIMEOUT, self.stdin.flush())
+        timeout(RPC_TIMEOUT, stdin.flush())
             .await
             .expect("timed out flushing subprocess stdin")
             .expect("flush of subprocess stdin failed");
@@ -158,11 +165,12 @@ impl Server {
     /// Write raw bytes verbatim to stdin (for malformed-input tests
     /// that intentionally do not produce a serialized `Value`).
     async fn send_raw(&mut self, bytes: &[u8]) {
-        timeout(RPC_TIMEOUT, self.stdin.write_all(bytes))
+        let stdin = self.stdin.as_mut().expect("stdin already closed");
+        timeout(RPC_TIMEOUT, stdin.write_all(bytes))
             .await
             .expect("timed out writing raw bytes to subprocess stdin")
             .expect("raw write to subprocess stdin failed");
-        timeout(RPC_TIMEOUT, self.stdin.flush())
+        timeout(RPC_TIMEOUT, stdin.flush())
             .await
             .expect("timed out flushing subprocess stdin")
             .expect("flush of subprocess stdin failed");
@@ -219,6 +227,29 @@ impl Server {
         });
         self.send_frame(&initialized).await;
         response
+    }
+
+    /// Close stdin to signal EOF to the child. After this, the child
+    /// should enter its graceful shutdown path (per rmcp service.rs
+    /// `QuitReason::Closed`). Caller should `wait_for_exit` to confirm
+    /// the child terminated cleanly.
+    ///
+    /// Sync (no `.await`) because dropping the `ChildStdin` closes the
+    /// pipe file descriptor immediately — no async work required.
+    fn close_stdin(&mut self) {
+        self.stdin.take();
+    }
+
+    /// Wait for the child to exit on its own. Does NOT call
+    /// `start_kill` — killing would mask a graceful-shutdown panic.
+    /// On timeout, panics; the Drop impl on Server will still
+    /// `start_kill` the runaway child as last-resort cleanup.
+    async fn wait_for_exit(&mut self, dur: Duration) -> std::process::ExitStatus {
+        match timeout(dur, self.child.wait()).await {
+            Ok(Ok(status)) => status,
+            Ok(Err(e)) => panic!("failed to wait for child: {e}"),
+            Err(_) => panic!("child did not exit within {dur:?}"),
+        }
     }
 }
 
@@ -535,4 +566,58 @@ async fn concurrent_calls_complete_independently() {
 
     drop(server); // explicit; otherwise Drop kills the child anyway.
     let _ = std::fs::remove_dir_all(&trace_dir);
+}
+
+/// Graceful shutdown (stdin EOF) must NOT panic the server.
+///
+/// rmcp enters a drain path on `QuitReason::Closed` (rmcp/src/service.rs
+/// line ~1061) that calls `tokio::time::timeout` to bound the response
+/// drain. Without `.enable_time()` on the runtime, the server panics
+/// every time a client disconnects gracefully.
+///
+/// The other tests in this file kill the subprocess via `start_kill`
+/// in `Server::Drop` and never reach the drain path — that's why CI
+/// passed for PR C / PR D despite this bug. This test instead closes
+/// stdin and waits for the child to exit naturally, asserting a clean
+/// exit status. If `.enable_time()` is ever removed from `cli.rs`, the
+/// child panics during drain and this test fails.
+///
+/// Discovered by the Phase 3A.2-E real-host validation gate against
+/// the MCP Python SDK 1.27.1 (whose stdio client closes stdin
+/// gracefully at session end).
+#[tokio::test(flavor = "multi_thread")]
+async fn graceful_shutdown_does_not_panic() {
+    let mut server = Server::spawn(None).await;
+    server.initialize().await;
+
+    // One tools/call so the drain has in-flight task state to flush
+    // (mirrors a typical session at disconnect time).
+    let id = server.next_id();
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": {
+            "name": "org.ncp-examples.echo-pipeline",
+            "arguments": {"shutdown_test": true},
+        },
+    });
+    server.send_frame(&req).await;
+    let resp = server.read_frame().await;
+    assert!(
+        resp.get("error").is_none(),
+        "tools/call before shutdown errored: {resp}"
+    );
+
+    // Close stdin → server reads EOF → enters rmcp's drain path.
+    server.close_stdin();
+
+    // Wait for the child to exit on its own (NOT via start_kill).
+    let status = server.wait_for_exit(Duration::from_secs(15)).await;
+    assert!(
+        status.success(),
+        "server did not exit cleanly on stdin EOF (likely a panic in the \
+         graceful-drain path of rmcp; ensure `.enable_time()` is called on \
+         the tokio runtime builder in cli.rs). status: {status:?}"
+    );
 }

--- a/docs/MCP_ADAPTER.md
+++ b/docs/MCP_ADAPTER.md
@@ -658,7 +658,7 @@ Each cell empirically verified by building a throwaway crate
 |---|---|---|---|
 | 1 | Crate name + features | ✅ pass | Above Cargo.toml clause builds clean. Features excluded: `macros`, `client`, `auth*`, all reqwest variants. |
 | 2 | Minimal stdio server example compiles | ✅ pass | `cargo check` exits 0 with zero warnings after fixing two deprecation warnings (see implementation notes below). |
-| 3 | Dependency tree size | ⚠ acceptable | **55 unique transitive crates** (`cargo tree --prefix none \| sort -u`). Includes tokio (multi-thread + io-std + macros), serde + serde_json, schemars, async-trait, futures, anyhow + procs. Non-trivial but unavoidable for a tokio MCP server — and justifies the §8 separate-crate decision. |
+| 3 | Dependency tree size | ⚠ acceptable | **55 unique transitive crates** (`cargo tree --prefix none \| sort -u`). Includes tokio (`rt-multi-thread + io-std + time` for normal deps; `macros + time + process + io-util` additionally for dev deps), serde + serde_json, schemars, async-trait, futures, anyhow + procs. Non-trivial but unavoidable for a tokio MCP server — and justifies the §8 separate-crate decision. |
 | 4 | Stdout/stderr behavior | ✅ pass (at API level) | `eprintln!` cleanly to stderr in the throwaway; `rmcp::transport::stdio()` owns stdin/stdout exclusively for protocol. Full process-level test under JSON-RPC load happens in PR C (§7). |
 | 5 | Compatibility with response shape (structuredContent + text mirror) | ✅ pass | Sample `CallToolResult` serialization produced exactly the MCP-spec-compliant wire shape: `{ "content": [{"type":"text","text":"..."}], "structuredContent": {...}, "isError": false }`. |
 | 6 | Dynamic tool registration without macros | ✅ pass | Manual `ServerHandler` impl with runtime-constructed `Vec<Tool>` compiles and dispatches. Zero `#[tool]` / `#[tool_router]` / `#[tool_handler]` macros used. `list_tools()` returns the runtime vector; `call_tool()` dispatches by name. |
@@ -703,9 +703,39 @@ renames to camelCase on the wire to match the MCP spec:
 | `input_schema` | `inputSchema` |
 | `output_schema` | `outputSchema` |
 
-**Tokio features needed:** `rt-multi-thread` (the async runtime),
-`macros` (the `#[tokio::main]` attribute), `io-std` (stdin/stdout
-access for rmcp's `transport-io`).
+**Tokio features and runtime drivers required (normal deps).**
+Three normal-deps features are required and the runtime builder
+must enable matching drivers:
+
+- `rt-multi-thread` — the multi-thread async runtime, built
+  manually in `cli.rs` (no `#[tokio::main]` — `fn main` is sync
+  so `--check` can exit before runtime construction).
+- `io-std` — `tokio::io::stdin` / `stdout` access for rmcp's
+  `transport-io` feature. `tokio::io::stdin`/`stdout` use
+  `spawn_blocking` internally rather than the reactor, so the I/O
+  driver does NOT need to be enabled with `.enable_io()`.
+- `time` — required by rmcp's graceful-shutdown drain path
+  (`rmcp/src/service.rs:1061` calls `tokio::time::timeout` to
+  bound the response drain on `QuitReason::Closed` /
+  `Cancelled`). The runtime builder MUST call `.enable_time()`
+  to activate the timer driver, even though no adapter code
+  directly uses `tokio::time`. Without it, the server panics on
+  every stdin EOF — the panic surfaces only on graceful client
+  shutdown, NOT during the request/response dialog. Earlier
+  PR C subprocess tests killed the child in `Server::Drop`, so
+  they did not exercise rmcp's graceful EOF drain path. The
+  PR D Python smoke also closed stdin, but originally printed
+  `SMOKE OK` before checking the server exit status, so it did
+  not catch the panic either. The Phase 3A.2-E MCP Python SDK
+  validation exposed the bug before publish. Regression
+  sentinels: `tests/mcp_protocol.rs::graceful_shutdown_does_not_panic`
+  (closes stdin, asserts clean exit) and the post-dialog
+  exit-status gate in `examples/mcp/ci_smoke.py` (added in the
+  same fix PR).
+
+Dev-deps additionally pull in `macros`, `time`, `process`, and
+`io-util` for tests. These dev-only features do not affect the
+adapter's normal `cargo install` dependency surface.
 
 **SDK version pin.** `rmcp = "1.7"` is a semver requirement (caret
 implied — picks any 1.x ≥ 1.7, blocks 2.0), NOT an exact pin. The

--- a/examples/mcp/ci_smoke.py
+++ b/examples/mcp/ci_smoke.py
@@ -10,7 +10,17 @@ Scope (per docs/MCP_ADAPTER.md): happy-path only. The full unit-of-PR-C
 protocol surface (unknown-tool errors, malformed-JSON errors,
 concurrent dispatch) is covered by `tests/mcp_protocol.rs`. This
 smoke verifies the adopter path: build → start → handshake →
-tools/list → tools/call → verify §5 response shape end-to-end.
+tools/list → tools/call → verify §5 response shape end-to-end → close
+stdin → assert the subprocess exits cleanly.
+
+The post-dialog exit-status gate is mandatory: rmcp's graceful-shutdown
+drain path (`rmcp/src/service.rs:1061`) requires the tokio time driver,
+and a missing `.enable_time()` panics the server only on stdin EOF —
+AFTER the last response has been sent. The dialog-only assertions
+would print SMOKE OK and miss the panic. This script asserts a clean
+exit code before printing SMOKE OK; if the subprocess exits non-zero
+after stdin close, the smoke fails with a clear message and the
+stderr tail. Mirrors `tests/mcp_protocol.rs::graceful_shutdown_does_not_panic`.
 
 Dependencies: Python stdlib only — subprocess, json, sys, pathlib,
 tempfile, threading.
@@ -356,21 +366,55 @@ def main() -> None:
 
     success = False
     try:
+        # 1. Run the JSON-RPC dialog and assert §5 response shape.
         run_smoke(proc, timeout_state)
-        print("SMOKE OK")
-        success = True
-    finally:
-        timer.cancel()
+
+        # 2. Graceful-shutdown gate: close stdin, wait for the child
+        # to exit on its own, assert a clean exit code. Without this
+        # gate, the script would print SMOKE OK as soon as the dialog
+        # succeeded — even if the server then panicked on stdin EOF
+        # in rmcp's drain path (rmcp/src/service.rs:1061, which
+        # requires the tokio time driver). The Phase 3A.2-E real-host
+        # validation gate caught that exact bug; this in-script gate
+        # is the regression sentinel against re-introduction. Mirrors
+        # tests/mcp_protocol.rs::graceful_shutdown_does_not_panic.
         if proc.stdin is not None:
             try:
                 proc.stdin.close()
             except (BrokenPipeError, OSError):
                 pass
         try:
-            proc.wait(timeout=5)
+            returncode = proc.wait(timeout=10)
         except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait()
+            fail(
+                "subprocess did not exit within 10s after stdin EOF "
+                "(graceful shutdown stalled)"
+            )
+        if returncode != 0:
+            fail(
+                f"subprocess exited non-zero after graceful shutdown: "
+                f"returncode={returncode}"
+            )
+
+        print("SMOKE OK")
+        success = True
+    finally:
+        timer.cancel()
+        # If the child is still alive here, it's because run_smoke or
+        # the graceful-shutdown gate raised before completing. Clean
+        # up the runaway process; the stderr tail from fail() already
+        # surfaced diagnostics.
+        if proc.poll() is None:
+            if proc.stdin is not None:
+                try:
+                    proc.stdin.close()
+                except (BrokenPipeError, OSError):
+                    pass
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
         try:
             stderr_log.close()
         except OSError:


### PR DESCRIPTION
## Summary

Found by the Phase 3A.2-E real-host validation gate against the MCP Python SDK 1.27.1: the adapter panicked on every stdin EOF.

rmcp's graceful-shutdown drain path (`rmcp/src/service.rs:1061`) calls `tokio::time::timeout` to bound the response drain. PR C built the tokio runtime with bare `.build()` under the assumption that v0 didn't need timers, because adapter code itself doesn't use `tokio::time`. That assumption was wrong about rmcp's internals.

Why CI didn't catch it:
- `tests/mcp_protocol.rs` kills the subprocess via `Server::Drop`'s `start_kill()` — never reaches the drain path.
- `examples/mcp/ci_smoke.py` closed stdin and waited, BUT printed `SMOKE OK` before checking the subprocess exit status.

The Python SDK's stdio client closes stdin gracefully at session end, triggering `QuitReason::Closed` in rmcp, hitting the timer-using drain, panicking the server.

## Fix

- **`Cargo.toml`** — add `"time"` to tokio normal-deps features (rmcp pulls it transitively; making it direct documents why).
- **`cli.rs`** — call `.enable_time()` on the runtime builder; comment updated to cite the exact rmcp file:line and to replace the now-falsified "v0 does not use tokio timers" claim.

## Regression sentinels (both bound to required CI)

- **`tests/mcp_protocol.rs::graceful_shutdown_does_not_panic`** — new test that closes stdin via the new `Server::close_stdin` (`Option<ChildStdin>` refactor) and asserts a clean exit via the new `Server::wait_for_exit`. NOT via `start_kill` — that would mask the panic. If `.enable_time()` is ever removed, this test fails.
- **`examples/mcp/ci_smoke.py`** — dialog success no longer suffices. The script now closes stdin, waits up to 10s for graceful exit, asserts `returncode == 0`, and only THEN prints `SMOKE OK`. The `mcp-smoke` required check now gates graceful shutdown too.

## Doc sync (`docs/MCP_ADAPTER.md`)

- §10 SDK matrix cell 3: refresh tokio feature list (`rt-multi-thread + io-std + time` normal; `macros + time + process + io-util` dev-only).
- §11 Tokio features block: expanded into a full features + runtime-driver requirements paragraph; documents the audit trail of how PR C tests and the original PR D smoke each failed to catch this, and names both regression sentinels.

## Test plan (the locked Phase 3A.2-E validation sequence, run locally)

- [x] `cargo build -p ncp-mcp-server --release --locked` — clean
- [x] `py /tmp/ncp-real-host-validation.py` — 15 [PASS], **no Tokio panic on stderr**, clean exit
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build -p ncp-mcp-server --locked` — clean
- [x] `cargo clippy -p ncp-mcp-server --locked --all-targets -- -D warnings` — clean
- [x] `cargo test -p ncp-mcp-server --locked` — **26/26** (15 naming + 5 loading + 6 mcp_protocol, including new `graceful_shutdown_does_not_panic`)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p ncp-mcp-server --no-deps --all-features` — clean
- [x] `py examples/mcp/ci_smoke.py` — `SMOKE OK` printed **only after** the new exit-status assertion path
- [ ] Required CI passes on this PR (including the new `mcp-smoke` gate which now also exercises graceful shutdown)

## Phase 3A.2-E status

Real-host validation gate complete after this lands. PR E (publish v0.1.0) unblocked.