### PR TITLE
chore(mcp): prepare ncp-mcp-server v0.1.0 publish (PR 3A.2-E)

### DIFF
--- a/crates/ncp-mcp-server/CHANGELOG.md
+++ b/crates/ncp-mcp-server/CHANGELOG.md
@@ -1,0 +1,35 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 Fabio Marcello Salvadori
+-->
+
+# Changelog — `ncp-mcp-server`
+
+All notable changes to the `ncp-mcp-server` crate are documented in this
+file. The root [`CHANGELOG.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/CHANGELOG.md)
+covers `ncp-runtime`, the NCP specification, and other project-wide
+changes.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-05-28
+
+### Added
+- Stdio MCP adapter binary.
+- One NCP graph exposed as one MCP tool.
+- Multi-graph support via repeated `--graph`.
+- Runtime-loaded dynamic tool list.
+- Object-shaped MCP arguments passed verbatim as graph root input.
+- `structuredContent` + text mirror response shape.
+- Per-call `trace_id` and optional `trace_path`.
+- `--trace-dir` support with per-call JSONL traces.
+- `--check` startup validation mode.
+- Process-level MCP protocol tests.
+- Graceful shutdown regression test for rmcp/tokio time driver.
+- CI smoke script and `mcp-smoke` required check.
+
+### Notes
+- Targets MCP spec 2025-11-25 over stdio only.
+- Streamable HTTP is out of scope for v0.1.0.
+- Rust module API is internal; CLI is the stable surface.

--- a/crates/ncp-mcp-server/Cargo.toml
+++ b/crates/ncp-mcp-server/Cargo.toml
@@ -15,6 +15,7 @@ include = [
     "tests/**",
     "Cargo.toml",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE",
     "NOTICE",
 ]

--- a/crates/ncp-mcp-server/README.md
+++ b/crates/ncp-mcp-server/README.md
@@ -5,6 +5,10 @@
 
 # ncp-mcp-server
 
+<p>
+  <a href="https://crates.io/crates/ncp-mcp-server"><img alt="crates.io" src="https://img.shields.io/crates/v/ncp-mcp-server?logo=rust&label=crates.io" /></a>&nbsp;<a href="https://docs.rs/ncp-mcp-server"><img alt="docs.rs" src="https://img.shields.io/docsrs/ncp-mcp-server" /></a>&nbsp;<a href="https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/rust-toolchain.toml"><img alt="MSRV" src="https://img.shields.io/crates/msrv/ncp-mcp-server" /></a>&nbsp;<a href="https://opensource.org/licenses/Apache-2.0"><img alt="License" src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" /></a>
+</p>
+
 A stdio [Model Context Protocol](https://modelcontextprotocol.io) adapter for
 [NCP](https://github.com/madeinplutofabio/neural-computation-protocol) —
 exposes auditable WASM Brick graphs as MCP tools that any MCP-compatible host
@@ -16,14 +20,12 @@ No glue code, no protocol translation in your app.
 
 ## Install
 
-From crates.io, after `v0.1.0` is published later in Phase 3A.2:
-
 ```bash
 cargo install ncp-mcp-server --locked
 ncp-mcp-server --version
 ```
 
-Until then, install from source:
+Source install fallback (latest unreleased main):
 
 ```bash
 git clone https://github.com/madeinplutofabio/neural-computation-protocol.git
@@ -31,16 +33,44 @@ cd neural-computation-protocol
 cargo install --path crates/ncp-mcp-server --locked
 ```
 
-Requires Rust 1.94+.
+Requires Rust **1.94+**.
 
-## Quick example
+## Wiring into an MCP-compatible host
 
-Multi-graph support from day one — repeat `--graph` for each graph:
+MCP-compatible desktop hosts and MCP-compatible CLI hosts typically read a
+JSON config that lists external MCP servers. The shape is documented by the
+MCP specification and used in common across hosts:
+
+```json
+{
+  "mcpServers": {
+    "ncp-echo-pipeline": {
+      "command": "/absolute/path/to/ncp-mcp-server",
+      "args": [
+        "--graph",
+        "/absolute/path/to/your/graph.yaml",
+        "--brick-dir",
+        "/absolute/path/to/your/bricks"
+      ]
+    }
+  }
+}
+```
+
+Paths MUST be absolute. The host's working directory at launch time varies
+across hosts.
+
+For a ready-to-customize example, a manual stdio dialog smoke recipe, and
+the CI smoke script that gates every PR, see the
+[MCP example directory](https://github.com/madeinplutofabio/neural-computation-protocol/tree/main/examples/mcp).
+
+## Quick example (multi-graph)
 
 ```bash
 ncp-mcp-server \
   --graph path/to/triage-graph.yaml \
   --graph path/to/extract-graph.yaml \
+  --brick-dir path/to/bricks \
   --trace-dir /tmp/ncp-mcp-traces
 ```
 
@@ -52,6 +82,7 @@ per-call execution traces, when `--trace-dir` is set, land in
 ## Documentation
 
 - [Design doc](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/MCP_ADAPTER.md) — binding architectural decisions for this adapter
+- [Examples](https://github.com/madeinplutofabio/neural-computation-protocol/tree/main/examples/mcp) — host config snippet, manual smoke recipe, CI smoke script
 - [NCP project README](https://github.com/madeinplutofabio/neural-computation-protocol) — what NCP is and why
 - [NCP install guide](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/INSTALL.md) — runtime + adapter install paths
 - [NCP adoption guide](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/ADOPTION_GUIDE.md) — how to use NCP in your stack

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -136,6 +136,29 @@ For more end-to-end tutorials (tracing, the hybrid-routing demo, embedding `ncp`
 
 ---
 
+## Install the MCP adapter
+
+`ncp-mcp-server` is a separate published crate that exposes NCP graphs as
+MCP tools over stdio. Install it independently of `ncp-runtime`:
+
+```bash
+cargo install ncp-mcp-server --locked
+ncp-mcp-server --version
+```
+
+Source install fallback:
+
+```bash
+git clone https://github.com/madeinplutofabio/neural-computation-protocol.git
+cd neural-computation-protocol
+cargo install --path crates/ncp-mcp-server --locked
+```
+
+For host configuration and smoke-test examples, see
+[`examples/mcp/README.md`](../examples/mcp/README.md).
+
+---
+
 ## Next steps
 
 - **Adopting NCP in your stack:** [`docs/ADOPTION_GUIDE.md`](ADOPTION_GUIDE.md)

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -423,3 +423,150 @@ This phase publishes **`ncp-runtime` only**. Brick crates
 (`ncp-echo`, `ncp-classifier-stub`) are `cdylib`s targeting
 `wasm32-unknown-unknown` and not useful as host-target deps; they're
 deferred to Phase 3A.4 (SDKs) when the brick-author workflow lands.
+
+---
+
+## Adapter publish (`ncp-mcp-server`)
+
+Crates.io-first publish flow for the MCP adapter crate. Phase 3A.2-E
+ships `ncp-mcp-server v0.1.0` to crates.io ONLY — **no GitHub Release,
+no GHCR image, no Zenodo archive**. The runtime publish ceremony
+(sections 1–8 above) does NOT apply to the adapter.
+
+### Why a distinct flow
+
+The existing `release.yml` and `docker.yml` workflows fire on
+`push: tags: ['v*']`. An adapter tag starting with `v` (e.g.
+`v0.1.0`) would trigger both workflows — wrong: they would publish a
+GitHub Release labeled with the adapter version but containing
+**runtime** binaries, and try to build/push a Docker image of the
+**runtime** workspace under the adapter tag. Broken provenance, wasted
+CI.
+
+**Adapter tags MUST NOT start with `v`.** Use the crate-name-prefixed
+pattern instead. This is the standard multi-crate Cargo workspace
+convention (compare `tokio-1.x.y`, `hyper-vX.Y.Z`).
+
+### Tag pattern (LOCKED)
+
+| Crate | Tag pattern | Workflows that fire on push |
+|---|---|---|
+| `ncp-runtime` | `v0.3.6`, `v0.3.7-rc.1`, etc. | `release.yml` + `docker.yml` (correct — runtime release) |
+| `ncp-mcp-server` | `ncp-mcp-server-v0.1.0`, `ncp-mcp-server-v0.1.0-rc.1`, etc. | **None** (correct — adapter is crates.io-first) |
+
+### Pre-flight gates (required from clean main)
+
+From an up-to-date `main` checkout:
+
+```bash
+cargo fmt --all -- --check
+cargo build -p ncp-mcp-server --locked
+cargo clippy -p ncp-mcp-server --locked --all-targets -- -D warnings
+cargo test -p ncp-mcp-server --locked
+RUSTDOCFLAGS="-D warnings" cargo doc -p ncp-mcp-server --no-deps --all-features
+cargo package -p ncp-mcp-server --list
+cargo publish -p ncp-mcp-server --dry-run --locked
+```
+
+All must exit 0. The `cargo package --list` step confirms the `.crate`
+contains `LICENSE`, `NOTICE`, `README.md`, and `CHANGELOG.md`
+(Apache 2.0 §4(d) compliance + the crates.io landing page).
+`cargo publish --dry-run` catches name squat, expired token, allowlist
+drift, and packaging metadata regressions.
+
+### README no-bare-link audit
+
+crates.io renders the crate-local `README.md` from inside the `.crate`
+archive. Relative paths that work on GitHub (`docs/...`, `examples/...`)
+will 404 because there is no `docs/` or `examples/` directory inside
+the `.crate`. The crate README was authored with absolute GitHub URLs;
+re-verify before publish by unpacking the `.crate` and grepping for
+bare repo-relative links (mirror the runtime gate in §3.1).
+
+### Release ceremony
+
+1. **RC tag.** From clean `main`:
+   ```bash
+   git tag -s ncp-mcp-server-v0.1.0-rc.1 -m "ncp-mcp-server v0.1.0 release candidate"
+   git push origin ncp-mcp-server-v0.1.0-rc.1
+   ```
+
+2. **Verify NO runtime workflows fire.** This is the success signal of
+   the tag-pattern discipline:
+   ```bash
+   gh run list --limit 10
+   ```
+   No `Release` or `Docker` workflow runs should appear for the RC tag.
+   If any runtime workflow fires:
+   **STOP** — the tag pattern was wrong. Abort the publish, delete
+   the tag, fix the pattern, and re-tag with the correct
+   `ncp-mcp-server-v*` form before retrying.
+
+3. **Verify the RC against the tagged commit** (not `main`, which may
+   have advanced):
+   ```bash
+   git fetch --tags origin
+   git checkout ncp-mcp-server-v0.1.0-rc.1
+   cargo publish -p ncp-mcp-server --dry-run --locked
+   # manual smoke: examples/mcp/echo-pipeline-mcp-smoke.md
+   git checkout main
+   ```
+   Adapter tags intentionally fire no Release/Docker workflows, so
+   this manual checkout-and-verify is the ONLY verification step.
+   Without it, the RC tag is just a label.
+
+4. **Clean the RC tag** (no GitHub Release to delete; no GHCR images):
+   ```bash
+   git push origin --delete ncp-mcp-server-v0.1.0-rc.1
+   git tag -d ncp-mcp-server-v0.1.0-rc.1
+   ```
+
+5. **Push the real tag** from clean `main`:
+   ```bash
+   git tag -s ncp-mcp-server-v0.1.0 -m "ncp-mcp-server v0.1.0"
+   git push origin ncp-mcp-server-v0.1.0
+   ```
+
+6. **Again verify NO runtime workflows fire** for the real tag:
+   ```bash
+   gh run list --limit 10
+   ```
+   Same STOP condition as step 2.
+
+7. **Publish to crates.io.** Use the lowest-privilege crates.io token
+   capable of publishing the new `ncp-mcp-server` crate, with a short
+   expiration such as 1 day. Revoke it immediately after publish.
+
+   Then publish against the tagged commit:
+   ```bash
+   git checkout ncp-mcp-server-v0.1.0
+   cargo publish -p ncp-mcp-server --locked
+   git checkout main
+   ```
+
+8. **Post-publish verification.**
+
+   Visit, in a browser:
+   - https://docs.rs/ncp-mcp-server/0.1.0 — docs.rs landing page
+     renders (no empty-Modules page)
+   - https://crates.io/crates/ncp-mcp-server/0.1.0 — crates.io page
+     renders the README with no broken links
+
+   Install path from a clean toolchain:
+   ```bash
+   cargo install ncp-mcp-server --locked
+   ncp-mcp-server --version    # expect: 0.1.0
+   ```
+
+   Audit every link in the rendered crates.io README. If any 404, ship
+   a tiny follow-up PR converting the broken link to an absolute
+   `https://github.com/.../blob/main/...` URL. Not a blocker for
+   v0.1.0 (cosmetic), but address within 1–2 days.
+
+### Scope
+
+This publishes **`ncp-mcp-server` only**. No GitHub Release artifacts
+(per-OS archives, SHA256SUMS) and no GHCR Docker image are produced
+for the adapter in v0.1.0. If binary-archive or container distribution
+demand surfaces later, an adapter-scoped release workflow
+(triggered by `ncp-mcp-server-v*` tags) can be added then.


### PR DESCRIPTION
## Summary

Publish-readiness PR for `ncp-mcp-server v0.1.0`. No code changes — only metadata, docs, and the crate-local CHANGELOG that ships in the packaged crate alongside the README.

**Phase 3A.2-E gate satisfied:** real-host validation against the MCP Python SDK 1.27.1 passes cleanly (the gating bug found there shipped as the fix in #25). PR E is now unblocked.

## Changes

- **`crates/ncp-mcp-server/Cargo.toml`** — add `"CHANGELOG.md"` to the explicit `include` allowlist. Without it, the new changelog would be skipped by `cargo package`.
- **`crates/ncp-mcp-server/README.md`** — finalize for the crates.io rendering. Add badges row (crates.io / docs.rs / MSRV / License); lead Install with `cargo install ncp-mcp-server --locked` (now real); source install demoted to fallback; new "Wiring into an MCP-compatible host" subsection with the generic `mcpServers` config snippet and a pointer to `examples/mcp/`. Quick example gains `--brick-dir` so it works from an installed-binary environment.
- **`crates/ncp-mcp-server/CHANGELOG.md`** — new file. Keep a Changelog format; initial `[0.1.0] - 2026-05-28` entry summarizing capabilities. Crate-local per decision #17; root `CHANGELOG.md` untouched.
- **`docs/INSTALL.md`** — new top-level `## Install the MCP adapter` section inserted before `## Next steps`.
- **`docs/PUBLISHING.md`** — new top-level `## Adapter publish (ncp-mcp-server)` section appended. Documents the crates.io-first flow, locked `ncp-mcp-server-v*` tag pattern (NOT `v*` — would fire the runtime `release.yml` + `docker.yml`), pre-flight gates, RC + real tag ceremony, post-publish verification. Crates.io-only — no GitHub Release, no GHCR image, no Zenodo for v0.1.0. Runtime publish ceremony (existing §1–§8) untouched.

## Test plan (locked Phase 3A.2-E verification sequence)

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build -p ncp-mcp-server --locked` — clean
- [x] `cargo clippy -p ncp-mcp-server --locked --all-targets -- -D warnings` — clean
- [x] `cargo test -p ncp-mcp-server --locked` — **6/6** in `mcp_protocol` (incl. `graceful_shutdown_does_not_panic`)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p ncp-mcp-server --no-deps --all-features` — clean
- [x] `cargo package -p ncp-mcp-server --list` — confirmed `README.md` + `CHANGELOG.md` + `LICENSE` + `NOTICE` + `Cargo.lock` all present (16 files, 147.0 KiB / 42.2 KiB compressed)
- [x] `cargo publish -p ncp-mcp-server --dry-run --locked` — clean; packaged-form compilation succeeded
- [ ] All 11 required CI checks pass on this PR

## After merge

Release ceremony per the new `docs/PUBLISHING.md "Adapter publish"` section:
1. RC tag `ncp-mcp-server-v0.1.0-rc.1` → verify NO runtime workflows fire → manual verify against RC checkout → clean RC tag.
2. Real tag `ncp-mcp-server-v0.1.0` → verify NO runtime workflows fire → `cargo publish` with short-TTL token → revoke token.
3. Post-publish verify: docs.rs landing renders, crates.io README links audit, fresh-toolchain install works.

Phase 3A.2 complete after publish.