### PR TITLE
docs(mcp): sync front-door docs after adapter publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/madeinplutofabio/neural-computation-protocol/actions/workflows/validate.yml"><img alt="CI" src="https://github.com/madeinplutofabio/neural-computation-protocol/actions/workflows/validate.yml/badge.svg" /></a>&nbsp;<a href="https://crates.io/crates/ncp-runtime"><img alt="crates.io" src="https://img.shields.io/crates/v/ncp-runtime?logo=rust&label=crates.io" /></a>&nbsp;<a href="https://docs.rs/ncp-runtime"><img alt="docs.rs" src="https://img.shields.io/docsrs/ncp-runtime" /></a>&nbsp;<a href="https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/rust-toolchain.toml"><img alt="MSRV" src="https://img.shields.io/crates/msrv/ncp-runtime" /></a>&nbsp;<a href="https://opensource.org/licenses/Apache-2.0"><img alt="License" src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" /></a>&nbsp;<a href="https://doi.org/10.5281/zenodo.19570209"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.19570209.svg?v=1" alt="DOI"></a>&nbsp;<a href="https://github.com/madeinplutofabio/neural-computation-protocol/releases"><img alt="Release" src="https://img.shields.io/github/v/release/madeinplutofabio/neural-computation-protocol?display_name=tag&include_prereleases" /></a>&nbsp;<a href="https://github.com/madeinplutofabio/neural-computation-protocol/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/madeinplutofabio/neural-computation-protocol?style=social" /></a>
+  <a href="https://github.com/madeinplutofabio/neural-computation-protocol/actions/workflows/validate.yml"><img alt="CI" src="https://github.com/madeinplutofabio/neural-computation-protocol/actions/workflows/validate.yml/badge.svg" /></a>&nbsp;<a href="https://crates.io/crates/ncp-runtime"><img alt="ncp-runtime on crates.io" src="https://img.shields.io/crates/v/ncp-runtime?logo=rust&label=ncp-runtime" /></a>&nbsp;<a href="https://crates.io/crates/ncp-mcp-server"><img alt="ncp-mcp-server on crates.io" src="https://img.shields.io/crates/v/ncp-mcp-server?logo=rust&label=ncp-mcp-server" /></a>&nbsp;<a href="https://docs.rs/ncp-runtime"><img alt="docs.rs" src="https://img.shields.io/docsrs/ncp-runtime" /></a>&nbsp;<a href="https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/rust-toolchain.toml"><img alt="MSRV" src="https://img.shields.io/crates/msrv/ncp-runtime" /></a>&nbsp;<a href="https://opensource.org/licenses/Apache-2.0"><img alt="License" src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" /></a>&nbsp;<a href="https://doi.org/10.5281/zenodo.19570209"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.19570209.svg?v=1" alt="DOI"></a>&nbsp;<a href="https://github.com/madeinplutofabio/neural-computation-protocol/releases"><img alt="Release" src="https://img.shields.io/github/v/release/madeinplutofabio/neural-computation-protocol?display_name=tag&include_prereleases" /></a>&nbsp;<a href="https://github.com/madeinplutofabio/neural-computation-protocol/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/madeinplutofabio/neural-computation-protocol?style=social" /></a>
 </p>
 
 ---
 
 **Docs:** [Adoption guide](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/ADOPTION_GUIDE.md) · [Benchmarks](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/BENCHMARK.md) · [Cost model](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/COST_MODEL.md) · [Roadmap](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/ROADMAP.md) · [Spec](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/spec/ncp-v0.2.3.md) · [Contributing](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/CONTRIBUTING.md) · [Security](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/SECURITY.md)
 
-**Status:** Protocol v0.2.3 + validator are stable. Reference runtime is available via [GitHub Releases](https://github.com/madeinplutofabio/neural-computation-protocol/releases/latest), [GHCR](https://github.com/madeinplutofabio/neural-computation-protocol/pkgs/container/ncp), and [crates.io](https://crates.io/crates/ncp-runtime) (Phase 3A.1 complete). Phase 3 now focuses on integrations (MCP/LangGraph adapters) and adoption.
+**Status:** Protocol v0.2.3 + validator are stable. Reference runtime is available via [GitHub Releases](https://github.com/madeinplutofabio/neural-computation-protocol/releases/latest), [GHCR](https://github.com/madeinplutofabio/neural-computation-protocol/pkgs/container/ncp), and [crates.io](https://crates.io/crates/ncp-runtime) (Phase 3A.1 complete). [`ncp-mcp-server v0.1.0`](https://crates.io/crates/ncp-mcp-server) is live on crates.io (Phase 3A.2 complete). Next adoption work: LangGraph wrapper + SDKs.
 
 ## What is NCP?
 
@@ -163,6 +163,59 @@ cargo run -p ncp-runtime --release --bin ncp-bench -- \
 
 ---
 
+## Use NCP from an MCP-compatible host
+
+Install the MCP adapter:
+
+```bash
+cargo install ncp-mcp-server --locked
+```
+
+Validate a graph before wiring it into a host:
+
+```bash
+ncp-mcp-server \
+  --graph /absolute/path/to/graph.yaml \
+  --brick-dir /absolute/path/to/bricks \
+  --trace-dir /absolute/path/to/traces \
+  --check
+```
+
+Run the adapter as a stdio MCP server:
+
+```bash
+ncp-mcp-server \
+  --graph /absolute/path/to/graph.yaml \
+  --brick-dir /absolute/path/to/bricks \
+  --trace-dir /absolute/path/to/traces
+```
+
+Minimal host config shape:
+
+```json
+{
+  "mcpServers": {
+    "ncp-my-graph": {
+      "command": "/absolute/path/to/ncp-mcp-server",
+      "args": [
+        "--graph",
+        "/absolute/path/to/graph.yaml",
+        "--brick-dir",
+        "/absolute/path/to/bricks",
+        "--trace-dir",
+        "/absolute/path/to/traces"
+      ]
+    }
+  }
+}
+```
+
+Each `--graph` becomes one MCP tool. The host sends a `tools/call`; NCP runs the graph; the adapter returns `structuredContent` plus a text mirror; and, when `--trace-dir` is set, each call writes a `<trace_id>.jsonl` trace.
+
+For ready-to-customize examples, see [examples/mcp/](https://github.com/madeinplutofabio/neural-computation-protocol/tree/main/examples/mcp).
+
+---
+
 ## Specification + tooling
 
 - **Protocol version:** v0.2.3
@@ -194,8 +247,10 @@ node dist/cli.js graph ../../examples/graphs/echo-chain/graph.yaml
 spec/            Protocol specification (Markdown + PDF releases)
 schemas/         JSON Schema for all NCP structures
 runtime/         Reference runtime (Rust) + bench harness
+crates/          Adapter crates (ncp-mcp-server: stdio MCP adapter)
 bricks/          Reference brick implementations (Rust -> WASM)
 examples/        Brick + graph manifests, fixtures, and demo graphs
+examples/mcp/    MCP host config snippet, smoke recipes, CI smoke script
 bench/           Datasets + machine-readable results (Windows + Linux)
 tools/           Validator CLI (ncp-validate)
 conformance/     Test vectors for runtime implementors

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -60,7 +60,53 @@ cargo run -p ncp-runtime --bin ncp -- run examples/graphs/echo-pipeline/graph.ya
 
 ---
 
-## 2) Understand the moving parts (2 minutes)
+## 2) Expose a graph as an MCP tool (3 minutes)
+
+If your agent host supports MCP, you can expose an NCP graph as a stdio MCP tool with `ncp-mcp-server`.
+
+Install:
+
+```bash
+cargo install ncp-mcp-server --locked
+```
+
+Validate startup without launching the server:
+
+```bash
+ncp-mcp-server \
+  --graph /absolute/path/to/graph.yaml \
+  --brick-dir /absolute/path/to/bricks \
+  --trace-dir /absolute/path/to/traces \
+  --check
+```
+
+Run as an MCP server:
+
+```bash
+ncp-mcp-server \
+  --graph /absolute/path/to/graph.yaml \
+  --brick-dir /absolute/path/to/bricks \
+  --trace-dir /absolute/path/to/traces
+```
+
+Practical flow:
+
+```
+MCP-compatible host
+→ tools/call
+→ ncp-mcp-server
+→ NCP graph execution
+→ structuredContent response
+→ optional JSONL trace file
+```
+
+Use this when an agent repeats a workflow often enough that it should not re-plan the same steps in the LLM conversation every time. Good fits include lead qualification, support-ticket routing, document triage, content research pipelines, code-change risk review, and data normalization before an agent acts.
+
+For host config examples and smoke-test recipes, see [`examples/mcp/README.md`](../examples/mcp/README.md).
+
+---
+
+## 3) Understand the moving parts (2 minutes)
 
 - **Brick**: a sandboxed WASM module that implements the NCP ABI (`alloc/free/invoke`).
 - **Graph**: nodes (bricks) + edges (routing + mapping).
@@ -76,7 +122,7 @@ Key folders:
 
 ---
 
-## 3) Run the “hybrid routing” demo (5 minutes)
+## 4) Run the “hybrid routing” demo (5 minutes)
 
 This graph models a production pattern:
 - Fast deterministic gate (classifier)
@@ -97,7 +143,7 @@ cargo run -p ncp-runtime --bin ncp -- run examples/graphs/support-routing-stubbe
 
 ---
 
-## 4) Turn on tracing (3 minutes)
+## 5) Turn on tracing (3 minutes)
 
 Tracing emits JSONL records with:
 - per-step provenance (trigger edge/node/step)
@@ -116,7 +162,7 @@ head -n 5 trace.jsonl
 
 ---
 
-## 5) Benchmarks you can cite (5 minutes)
+## 6) Benchmarks you can cite (5 minutes)
 
 ### 5.1 Pure runtime overhead
 ```bash
@@ -142,7 +188,7 @@ cargo run --release -p ncp-runtime --bin ncp-bench --   examples/graphs/support-
 
 ---
 
-## 6) Embed NCP in a Rust service (10 minutes)
+## 7) Embed NCP in a Rust service (10 minutes)
 
 If you want to call the runtime from your own Rust app (HTTP server, worker, agent framework),
 use the library API (`RuntimeContext`) rather than shelling out to the CLI.
@@ -183,7 +229,7 @@ fn main() -> anyhow::Result<()> {
 
 ---
 
-## 7) How teams typically adopt NCP (the realistic path)
+## 8) How teams typically adopt NCP (the realistic path)
 
 ### Step A — Start with a “gate + escalate” graph
 - deterministic validator (schema, regex, keyword, rules)
@@ -201,7 +247,7 @@ fn main() -> anyhow::Result<()> {
 
 ---
 
-## 8) Where NCP fits vs common agent stacks
+## 9) Where NCP fits vs common agent stacks
 
 NCP is not trying to replace:
 - planners, memory systems, multi-agent messaging, orchestration UIs
@@ -218,13 +264,15 @@ It **does** replace or harden:
 
 ---
 
-## 9) Production readiness (current scope and what’s next)
+## 10) Production readiness (current scope and what’s next)
 
 The reference runtime’s distribution channels are live as of Phase 3A.1 — available
 through [GitHub Releases](https://github.com/madeinplutofabio/neural-computation-protocol/releases/latest),
 [GHCR](https://github.com/madeinplutofabio/neural-computation-protocol/pkgs/container/ncp),
-and [crates.io](https://crates.io/crates/ncp-runtime). It’s a strong base for
-evaluation and internal pilots:
+and [crates.io](https://crates.io/crates/ncp-runtime). The MCP adapter is live as
+of Phase 3A.2 — install with `cargo install ncp-mcp-server --locked` (see
+[crates.io](https://crates.io/crates/ncp-mcp-server)). Together they’re a
+strong base for evaluation and internal pilots:
 - deterministic routing + mapping
 - sandboxed WASM invokes
 - trace output and safety budgets
@@ -236,15 +284,15 @@ But **production hardening** typically needs:
 - real LLM adapters + token accounting
 - threat model + security review checklist
 
-Next adoption work focuses on integrations (MCP / LangGraph adapters),
-brick packs, and SDKs (Phase 3A.2–3A.5). Deeper hardening lands in
-Phase 3C, and the production wrapper in Phase 4. See
+Next adoption work focuses on the LangGraph wrapper, brick packs, and
+SDKs (Phase 3A.3–3A.5; the MCP adapter shipped as Phase 3A.2). Deeper
+hardening lands in Phase 3C, and the production wrapper in Phase 4. See
 [`docs/ROADMAP.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/ROADMAP.md)
 for the full track breakdown.
 
 ---
 
-## 10) Next contribution opportunities (high-leverage)
+## 11) Next contribution opportunities (high-leverage)
 
 If you want to contribute something *immediately useful*:
 - Add a new deterministic brick (PII scrubber, validator, router gate)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -142,7 +142,12 @@ For more end-to-end tutorials (tracing, the hybrid-routing demo, embedding `ncp`
 MCP tools over stdio. Install it independently of `ncp-runtime`:
 
 ```bash
+# Latest published version
 cargo install ncp-mcp-server --locked
+
+# Or pin to a specific version for reproducibility
+cargo install ncp-mcp-server --version 0.1.0 --locked
+
 ncp-mcp-server --version
 ```
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -160,6 +160,8 @@ This section reflects the latest released state. Keep it honest and specific; up
 
 ### 3A.1 Packaging & install paths (first)
 
+**Status:** ✅ Complete (shipped 2026-05-27 — `ncp-runtime v0.3.6` on [crates.io](https://crates.io/crates/ncp-runtime), [GitHub Releases](https://github.com/madeinplutofabio/neural-computation-protocol/releases/latest), [GHCR](https://github.com/madeinplutofabio/neural-computation-protocol/pkgs/container/ncp)).
+
 **Deliverables**
 - Prebuilt binaries for linux/darwin/windows (x86_64 + aarch64 where applicable)
 - `cargo install` story is stable (pick final bin name now: `ncp`)
@@ -170,6 +172,8 @@ This section reflects the latest released state. Keep it honest and specific; up
 - New user: install → run a reference graph → view trace in < 10 minutes
 
 ### 3A.2 MCP adapter (highest leverage wedge)
+
+**Status:** ✅ Complete (shipped 2026-05-28 — [`ncp-mcp-server v0.1.0`](https://crates.io/crates/ncp-mcp-server) on crates.io).
 
 **Deliverables**
 - `ncp-mcp-server` that exposes: **one graph = one MCP tool**

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -29,11 +29,18 @@ and that graph becomes a callable tool with no glue code.
 
 ---
 
-## Quick start (source install)
+## Quick start
 
-> `ncp-mcp-server` is not yet on crates.io (Phase 3A.2-E ships
-> `cargo install ncp-mcp-server --locked`). Until then, build it
-> from source in a workspace checkout.
+### Install from crates.io
+
+```bash
+cargo install ncp-mcp-server --locked
+ncp-mcp-server --version
+```
+
+### Source install (fallback)
+
+For pre-release builds or workspace development:
 
 ```bash
 # 1. Clone the workspace


### PR DESCRIPTION
## Summary

Closes the gap noticed right after #26 merged: `ncp-mcp-server v0.1.0` is live on crates.io, but the front-door docs still treated MCP as future work — root README Status line said "Phase 3 now focuses on integrations (MCP/LangGraph adapters)", Adoption Guide listed MCP under "next adoption work", and `examples/mcp/README.md` still warned "not yet on crates.io".

An adopter landing on github.com would have missed that the adapter is installable today. This PR adds practical install + run + host-config sections to both the root README and the Adoption Guide, plus the small status/discoverability refreshes.

## Front-door practical sections (new)

- **`README.md`** — new `## Use NCP from an MCP-compatible host` section: install / `--check` / run / minimal `mcpServers` config JSON. Sits between Quick start (runtime) and Specification + tooling so the discovery flow reads: install runtime → run a graph locally → expose a graph to an MCP host.
- **`docs/ADOPTION_GUIDE.md`** — new `## 2) Expose a graph as an MCP tool (3 minutes)` right after the local-run section. Includes the practical flow diagram and use-case callouts (lead qualification, support-ticket routing, document triage, etc.). Sections §2–§10 renumbered to §3–§11 to make room; verified no internal cross-references use the old numbers.

## Status / discoverability refreshes

- `README.md` badges: add a distinguishable `ncp-mcp-server` crates.io badge.
- `README.md` Status line: name `ncp-mcp-server v0.1.0` as the Phase 3A.2 deliverable; reframe "next adoption work" to LangGraph + SDKs.
- `README.md` Repository structure: add `crates/` and `examples/mcp/`.
- `docs/ROADMAP.md`: add `Status: ✅ Complete` markers under §3A.1 (runtime shipped 2026-05-27) and §3A.2 (adapter shipped 2026-05-28).
- `docs/ADOPTION_GUIDE.md` §10 production-readiness: name the MCP adapter alongside runtime distribution channels.

## Smaller adopter-path tidies

- `docs/INSTALL.md`: add a `--version 0.1.0` pinned-install example beside the unversioned form (Phase 3A.1 PR H pattern).
- `examples/mcp/README.md`: drop the stale "not yet on crates.io" blockquote; restructure Quick start to lead with crates.io install, demote source install to fallback.

## Test plan

- [x] `cargo build -p ncp-mcp-server --release --locked` — clean (1m 48s)
- [x] `py examples/mcp/ci_smoke.py` — `SMOKE OK` (post-publish gate still passes)
- [x] Stale-marker grep across `README.md`, `docs/`, `examples/mcp/` for `"not yet on crates.io"`, `"coming later"`, `"Phase 3 now focuses on integrations (MCP/LangGraph adapters)"`, `"MCP / LangGraph adapters"` — zero matches
- [x] `docs/ADOPTION_GUIDE.md` section numbering: §0–§11 sequential, new §2 inserted, no duplicates
- [ ] All 11 required CI checks pass (including `mcp-smoke`)

No code changes. No CHANGELOG update — Phase 3A.2-E's v0.1.0 entry already names the shipped capabilities; this PR is purely doc drift catch-up.