### PR TITLE
build(langgraph): ncp-langgraph v0.1.0.dev0 package skeleton (PR 3A.3-B)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,6 +102,75 @@ jobs:
       - run: python3 examples/mcp/ci_smoke.py
 
   # ──────────────────────────────────────────────────────────────────────
+  # LANGGRAPH TEST JOB: builds the ncp-mcp-server release binary, installs
+  # the ncp-langgraph Python package with its [dev] extras (ruff, mypy,
+  # pytest, build, twine), and runs the package-local gates:
+  #   - ruff check  (lint)
+  #   - ruff format --check  (format gate)
+  #   - mypy --strict src  (type gate)
+  #   - pytest  (smoke tests; NCP_MCP_SERVER is exported for PR C+
+  #     integration tests once they land)
+  #   - python -m build + wheel py.typed check + twine check
+  #     (verifies the PEP 561 marker survives the wheel build and
+  #     that PyPI metadata + README render correctly)
+  #
+  # Every Python tool is invoked via `python -m <tool>` so it binds to
+  # the interpreter set up by actions/setup-python@v5, not to whatever
+  # the runner image's system Python ships on PATH. This prevents the
+  # failure mode where a system-installed ruff/mypy/pytest silently runs
+  # against the wrong site-packages.
+  #
+  # Python is PINNED to 3.10 via actions/setup-python@v5 so the
+  # `requires-python = ">=3.10"` claim in pyproject.toml is tested at
+  # the floor of the supported range, not at whatever the runner image
+  # ships by default.
+  #
+  # ADVISORY ONLY in PR B. This job becomes a required check only AFTER
+  # Phase 3A.3 PR G merges (per docs/BRANCH_PROTECTION.md "Adding new
+  # required checks"). Until then, future PRs can technically merge with
+  # langgraph-test failing.
+  # ──────────────────────────────────────────────────────────────────────
+  langgraph-test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - uses: Swatinem/rust-cache@v2
+        with: { key: langgraph-test }
+      - name: Build ncp-mcp-server release binary
+        run: cargo build -p ncp-mcp-server --release --locked
+      - name: Install ncp-langgraph with [dev] extras
+        working-directory: python/ncp-langgraph
+        run: python -m pip install -e ".[dev]"
+      - name: Lint (ruff check)
+        working-directory: python/ncp-langgraph
+        run: python -m ruff check .
+      - name: Format check (ruff format)
+        working-directory: python/ncp-langgraph
+        run: python -m ruff format --check .
+      - name: Type check (mypy --strict over src/)
+        working-directory: python/ncp-langgraph
+        run: python -m mypy --strict src
+      - name: Pytest
+        working-directory: python/ncp-langgraph
+        env:
+          NCP_MCP_SERVER: ${{ github.workspace }}/target/release/ncp-mcp-server
+        run: python -m pytest
+      - name: Build wheel + verify py.typed marker + twine check
+        working-directory: python/ncp-langgraph
+        run: |
+          rm -rf dist/
+          python -m build
+          python -c "import zipfile, pathlib; w=next(pathlib.Path('dist').glob('*.whl')); names=set(zipfile.ZipFile(w).namelist()); assert 'ncp_langgraph/py.typed' in names, names; print('py.typed present in wheel')"
+          python -m twine check dist/*
+
+  # ──────────────────────────────────────────────────────────────────────
   # WASM JOB: build & lint the brick crates for wasm32-unknown-unknown.
   # Brick crates are LIBRARY targets that can only compile to WASM.
   # If you find yourself moving these into the host matrix, STOP — they

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@ node_modules/
 # Build output
 dist/
 
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+
 # TypeScript cache
 *.tsbuildinfo
 

--- a/python/ncp-langgraph/CHANGELOG.md
+++ b/python/ncp-langgraph/CHANGELOG.md
@@ -1,0 +1,43 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 Fabio Marcello Salvadori
+-->
+
+# Changelog
+
+All notable changes to `ncp-langgraph` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+`ncp-langgraph` is versioned independently from `ncp-runtime` and
+`ncp-mcp-server`; bumps reflect adapter API or behavior changes only.
+
+## [Unreleased]
+
+### Added
+
+- Package skeleton (`pyproject.toml`, src-layout, hatchling backend).
+- Public API surface stubs: `NCPNode`, `NCPNode.from_subprocess(...)`,
+  `call_ncp_graph(...)`, `RunnerResult` dataclass, and exception
+  hierarchy (`NCPError`, `NCPSubprocessError`, `NCPInvocationError`,
+  `NCPTimeoutError`, `NCPAmbiguousToolError`). Executable API paths
+  (`NCPNode.from_subprocess(...)`, `NCPNode.__call__(...)`, and
+  `call_ncp_graph(...)`) raise `NotImplementedError` until PR C and
+  PR D land the implementations.
+- PEP 561 `py.typed` marker so type-checkers consume the package's
+  inline type information.
+- Build/lint/test tooling: `ruff` (lint + format), `mypy --strict` over
+  `src/`, `pytest`. Available via `pip install -e .[dev]`.
+- `langgraph-test` CI job in `.github/workflows/rust.yml` (advisory
+  until Phase 3A.3 PR G merges).
+
+### Notes
+
+- This package skeleton uses version `0.1.0.dev0` and is NOT intended
+  for end-user installation. It exists to lock the package layout,
+  build pipeline, and CI gate before implementation work begins.
+- The locked design contract for v0.1.0 lives in
+  [`docs/LANGGRAPH_ADAPTER.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/LANGGRAPH_ADAPTER.md).
+
+[Unreleased]: https://github.com/madeinplutofabio/neural-computation-protocol/commits/main/python/ncp-langgraph

--- a/python/ncp-langgraph/LICENSE
+++ b/python/ncp-langgraph/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Fabio Marcello Salvadori
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/python/ncp-langgraph/NOTICE
+++ b/python/ncp-langgraph/NOTICE
@@ -1,0 +1,7 @@
+NCP — Neural Computation Protocol
+Copyright 2026 Fabio Marcello Salvadori
+
+This product includes software developed by Fabio Marcello Salvadori.
+
+Licensed under the Apache License, Version 2.0.
+See the LICENSE file for the full license text.

--- a/python/ncp-langgraph/README.md
+++ b/python/ncp-langgraph/README.md
@@ -1,0 +1,80 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 Fabio Marcello Salvadori
+-->
+
+# ncp-langgraph
+
+> **Pre-release placeholder.** `ncp-langgraph v0.1.0.dev0` is the
+> skeleton package for the upcoming v0.1.0 release. The public API
+> surface is stubbed but not yet implemented; the executable API paths
+> (`NCPNode.from_subprocess(...)`, `NCPNode.__call__(...)`, and
+> `call_ncp_graph(...)`) raise `NotImplementedError`. Track progress
+> on the
+> [Phase 3A.3 milestone](https://github.com/madeinplutofabio/neural-computation-protocol/issues?q=is%3Aissue+label%3Aphase-3.A.3).
+
+LangGraph adapter for the
+[Neural Computation Protocol (NCP)](https://github.com/madeinplutofabio/neural-computation-protocol).
+
+`ncp-langgraph` will let a LangGraph `StateGraph` invoke an NCP graph
+as a node by spawning the
+[`ncp-mcp-server`](https://crates.io/crates/ncp-mcp-server) binary and
+talking to it over stdio. One NCP graph = one LangGraph node. No glue
+code, no protocol-buffer plumbing, no PyO3 (in v0.1.0).
+
+## Status
+
+- **v0.1.0.dev0** (this release): package skeleton + build/lint/test
+  scaffolding. No runnable API.
+- **v0.1.0** (next release): `NCPNode.from_subprocess(...)` and
+  `call_ncp_graph(...)` shipped against the locked design contract
+  in
+  [`docs/LANGGRAPH_ADAPTER.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/LANGGRAPH_ADAPTER.md).
+
+## Scope (v0.1.0)
+
+- **Invocation strategy:** subprocess via `ncp-mcp-server` over stdio
+  JSON-RPC. No HTTP transport, no PyO3 binding in v0.
+- **Sync only.** `NCPAsyncNode` is a v0.2.0+ addition.
+- **One subprocess per call.** No persistent pool in v0.1.0 (deferred).
+- **One graph per `NCPNode` instance.** Multi-graph adapter instances
+  are a v0.2.0+ addition.
+
+For the full design contract, locked signature, state semantics, and
+exception model, see
+[`docs/LANGGRAPH_ADAPTER.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/LANGGRAPH_ADAPTER.md).
+
+## Install
+
+```bash
+pip install ncp-langgraph
+```
+
+`ncp-langgraph` requires the `ncp-mcp-server` binary at runtime. Install
+it separately from crates.io:
+
+```bash
+cargo install ncp-mcp-server --locked
+```
+
+The Python package does not bundle the binary because pip cannot ship a
+Rust executable.
+
+## Requirements
+
+- Python 3.10+
+- `ncp-mcp-server v0.1.x` on `PATH` or an absolute path passed via
+  `NCPNode.from_subprocess(binary=...)`
+- LangGraph 1.x
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).
+
+## Links
+
+- [NCP project](https://github.com/madeinplutofabio/neural-computation-protocol)
+- [Design doc](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/LANGGRAPH_ADAPTER.md)
+- [MCP adapter (`ncp-mcp-server`)](https://crates.io/crates/ncp-mcp-server)
+- [Changelog](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/python/ncp-langgraph/CHANGELOG.md)
+- [Issues](https://github.com/madeinplutofabio/neural-computation-protocol/issues)

--- a/python/ncp-langgraph/pyproject.toml
+++ b/python/ncp-langgraph/pyproject.toml
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ncp-langgraph"
+version = "0.1.0.dev0"
+description = "LangGraph adapter for NCP: invoke NCP graphs as LangGraph nodes via ncp-mcp-server subprocess."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+authors = [
+    { name = "Fabio Marcello Salvadori" },
+]
+keywords = [
+    "ncp",
+    "neural-computation-protocol",
+    "langgraph",
+    "mcp",
+    "agent",
+    "workflow",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+dependencies = [
+    "langgraph>=1.0.0,<2.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "ruff",
+    "mypy",
+    "pytest",
+    "build",
+    "twine",
+]
+
+[project.urls]
+Homepage = "https://github.com/madeinplutofabio/neural-computation-protocol"
+Repository = "https://github.com/madeinplutofabio/neural-computation-protocol"
+Issues = "https://github.com/madeinplutofabio/neural-computation-protocol/issues"
+Changelog = "https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/python/ncp-langgraph/CHANGELOG.md"
+Documentation = "https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/LANGGRAPH_ADAPTER.md"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ncp_langgraph"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/ncp_langgraph",
+    "tests",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE",
+    "NOTICE",
+    "pyproject.toml",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "UP",  # pyupgrade
+]
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+files = ["src"]
+explicit_package_bases = true
+mypy_path = "src"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"

--- a/python/ncp-langgraph/src/ncp_langgraph/__init__.py
+++ b/python/ncp-langgraph/src/ncp_langgraph/__init__.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+
+"""LangGraph adapter for the Neural Computation Protocol (NCP).
+
+`ncp-langgraph` lets a LangGraph `StateGraph` invoke an NCP graph as a
+node by spawning the `ncp-mcp-server` binary and talking to it over
+stdio.
+
+The locked design contract is documented in
+`docs/LANGGRAPH_ADAPTER.md` in the NCP repository.
+
+Public API:
+
+- :class:`NCPNode` -- LangGraph-callable wrapper. Factory:
+  :meth:`NCPNode.from_subprocess`.
+- :func:`call_ncp_graph` -- lower-level function that returns a
+  :class:`RunnerResult` directly, for callers not using LangGraph state.
+- :class:`RunnerResult` -- frozen dataclass returned by
+  :func:`call_ncp_graph`.
+- Exception hierarchy: :class:`NCPError` (base),
+  :class:`NCPSubprocessError`, :class:`NCPInvocationError`,
+  :class:`NCPTimeoutError`, :class:`NCPAmbiguousToolError`.
+"""
+
+from ncp_langgraph.node import NCPNode
+from ncp_langgraph.subprocess_runner import call_ncp_graph
+from ncp_langgraph.types import (
+    NCPAmbiguousToolError,
+    NCPError,
+    NCPInvocationError,
+    NCPSubprocessError,
+    NCPTimeoutError,
+    RunnerResult,
+)
+
+__version__ = "0.1.0.dev0"
+
+__all__ = [
+    "NCPNode",
+    "call_ncp_graph",
+    "RunnerResult",
+    "NCPError",
+    "NCPSubprocessError",
+    "NCPInvocationError",
+    "NCPTimeoutError",
+    "NCPAmbiguousToolError",
+    "__version__",
+]

--- a/python/ncp-langgraph/src/ncp_langgraph/node.py
+++ b/python/ncp-langgraph/src/ncp_langgraph/node.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+
+"""NCPNode: LangGraph-callable wrapper around `ncp-mcp-server`.
+
+Per the locked design contract in `docs/LANGGRAPH_ADAPTER.md` (§3.1
++ §3.2 + §4), an `NCPNode` instance is callable. Construct via the
+locked classmethod factory :meth:`NCPNode.from_subprocess`; register
+the instance as a LangGraph node via
+``builder.add_node(name, instance)``.
+
+The LangGraph execution surface is ``__call__(state)``, which performs
+the locked four-frame MCP dialog against `ncp-mcp-server` (via
+:func:`ncp_langgraph.call_ncp_graph` internally) and returns a PARTIAL
+state-update dict. It does NOT mutate the input state.
+
+Skeleton stage: :meth:`NCPNode.from_subprocess` and
+:meth:`NCPNode.__call__` are stubs. The real implementation lands in
+Phase 3A.3 PR D.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+class NCPNode:
+    """LangGraph-callable wrapper around an `ncp-mcp-server` graph.
+
+    The only supported way to construct an `NCPNode` in v0.1.0 is via
+    the :meth:`from_subprocess` classmethod factory. Instances are
+    callable so they work directly as LangGraph nodes:
+
+    .. code-block:: python
+
+        node = NCPNode.from_subprocess(graph="...", brick_dir="...")
+        builder.add_node("ncp_step", node)
+
+    Each instance binds one graph configuration; construct a separate
+    `NCPNode` per graph.
+    """
+
+    @classmethod
+    def from_subprocess(
+        cls,
+        graph: str | Path,
+        brick_dir: str | Path,
+        trace_dir: str | Path | None = None,
+        binary: str | Path = "ncp-mcp-server",
+        tool_name: str | None = None,
+        input_key: str | None = None,
+        output_key: str = "ncp_output",
+        trace_key: str = "ncp_trace",
+        timeout: float = 30.0,
+    ) -> NCPNode:
+        """Construct an `NCPNode` that drives `ncp-mcp-server` over stdio.
+
+        Each call to the returned node spawns a fresh `ncp-mcp-server`
+        subprocess, performs the four-frame MCP dialog
+        (``initialize`` -> ``notifications/initialized`` ->
+        ``tools/list`` -> ``tools/call``), and returns a partial
+        LangGraph state-update dict.
+
+        Args:
+            graph: Path to the NCP graph YAML manifest. Forwarded to
+                `ncp-mcp-server --graph`.
+            brick_dir: Path to the directory containing the graph's
+                brick WASM artifacts. Forwarded to
+                `ncp-mcp-server --brick-dir`.
+            trace_dir: If set, each call writes a per-call JSONL trace
+                under this directory. `None` disables tracing.
+            binary: Name or absolute path of the `ncp-mcp-server`
+                executable. The default ``"ncp-mcp-server"`` resolves
+                through `PATH`.
+            tool_name: MCP tool name to invoke. If `None`, auto-derived
+                from a single-tool ``tools/list`` response.
+            input_key: If set, only ``state[input_key]`` is passed to
+                MCP ``tools/call`` arguments. If `None`, the whole
+                LangGraph state dict is passed verbatim.
+            output_key: Key under which
+                ``structuredContent.output_json`` is returned in the
+                state-update dict. Default ``"ncp_output"``.
+            trace_key: Key under which the trace-metadata dict is
+                returned in the state-update dict. Default
+                ``"ncp_trace"``.
+            timeout: Wall-clock timeout in seconds for the full
+                invocation (spawn + dialog + close + wait-for-exit).
+
+        Returns:
+            A configured :class:`NCPNode` instance ready for
+            registration via ``builder.add_node(name, instance)``.
+
+        Raises:
+            NotImplementedError: Always, in the v0.1.0.dev0 skeleton.
+                Real implementation lands in Phase 3A.3 PR D.
+        """
+        raise NotImplementedError(
+            "NCPNode.from_subprocess is a skeleton stub in "
+            "ncp-langgraph v0.1.0.dev0. The real implementation lands "
+            "in Phase 3A.3 PR D. See docs/LANGGRAPH_ADAPTER.md §3.1 "
+            "for the locked contract."
+        )
+
+    def __call__(self, state: dict[str, Any]) -> dict[str, Any]:
+        """Invoke the bound NCP graph and return a partial state update.
+
+        Returns a NEW dict containing exactly two keys (the configured
+        ``output_key`` and ``trace_key``). Does NOT mutate the input
+        ``state``. The LangGraph runtime applies this partial update
+        according to the `StateGraph` state schema and reducers.
+
+        Args:
+            state: The current LangGraph state dict. Passed verbatim
+                as MCP ``tools/call`` arguments unless ``input_key``
+                is set, in which case only ``state[input_key]`` is
+                sent.
+
+        Returns:
+            A new dict
+            ``{output_key: <output_json>, trace_key: <trace_metadata>}``
+            where ``<trace_metadata>`` has the shape
+            ``{"result_type": str, "trace_id": str, "trace_path": str | None}``.
+
+        Raises:
+            NCPSubprocessError: Spawn failed, non-zero exit, malformed
+                JSON-RPC frames, or a JSON-RPC error response.
+            NCPInvocationError: The graph ran to a non-success terminal
+                (MCP ``result.isError == true``).
+            NCPTimeoutError: The configured ``timeout`` was exceeded.
+            NCPAmbiguousToolError: ``tools/list`` returned multiple
+                tools and ``tool_name`` was not provided.
+            NotImplementedError: Always, in the v0.1.0.dev0 skeleton.
+                Real implementation lands in Phase 3A.3 PR D.
+        """
+        raise NotImplementedError(
+            "NCPNode.__call__ is a skeleton stub in "
+            "ncp-langgraph v0.1.0.dev0. The real implementation lands "
+            "in Phase 3A.3 PR D. See docs/LANGGRAPH_ADAPTER.md §3.2 "
+            "+ §4 for the locked contract."
+        )

--- a/python/ncp-langgraph/src/ncp_langgraph/subprocess_runner.py
+++ b/python/ncp-langgraph/src/ncp_langgraph/subprocess_runner.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+
+"""Subprocess runner: drives `ncp-mcp-server` over stdio JSON-RPC.
+
+This module is the lower-level entry point for invoking an NCP graph
+without LangGraph state semantics. :class:`ncp_langgraph.NCPNode` is
+the LangGraph-callable wrapper built on top of :func:`call_ncp_graph`.
+
+Per the locked design contract in `docs/LANGGRAPH_ADAPTER.md` (§3.3 +
+§5), each :func:`call_ncp_graph` invocation spawns a fresh
+`ncp-mcp-server` subprocess, performs the four-frame dialog
+(``initialize`` -> ``notifications/initialized`` -> ``tools/list`` ->
+``tools/call``), closes stdin gracefully, and asserts a clean exit.
+
+Skeleton stage: this is a stub. The real implementation lands in
+Phase 3A.3 PR C.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ncp_langgraph.types import RunnerResult
+
+
+def call_ncp_graph(
+    graph: str | Path,
+    brick_dir: str | Path,
+    arguments: dict[str, Any],
+    *,
+    trace_dir: str | Path | None = None,
+    binary: str | Path = "ncp-mcp-server",
+    tool_name: str | None = None,
+    timeout: float = 30.0,
+) -> RunnerResult:
+    """Invoke an NCP graph by driving `ncp-mcp-server` over stdio.
+
+    Spawns a fresh `ncp-mcp-server` subprocess, performs the locked
+    four-frame MCP dialog, returns the result, and shuts the subprocess
+    down. Each call is independent; there is no subprocess pool in
+    v0.1.0.
+
+    Args:
+        graph: Path to the NCP graph YAML manifest. Forwarded to
+            `ncp-mcp-server --graph`.
+        brick_dir: Path to the directory containing the graph's brick
+            WASM artifacts. Forwarded to `ncp-mcp-server --brick-dir`.
+        arguments: The arguments object passed to MCP `tools/call`.
+            This is the input the NCP graph sees as its root input.
+        trace_dir: If set, forwarded to `ncp-mcp-server --trace-dir`.
+            Causes the subprocess to write a JSONL trace file per
+            invocation. When `None`, tracing is disabled and
+            `RunnerResult.trace["trace_path"]` is `None`.
+        binary: Name or absolute path of the `ncp-mcp-server`
+            executable. The default ``"ncp-mcp-server"`` resolves
+            through `PATH`.
+        tool_name: MCP tool name to invoke. If `None`, auto-derived
+            from a single-tool ``tools/list`` response; raises
+            :class:`ncp_langgraph.NCPAmbiguousToolError` if the server
+            exposes multiple tools.
+        timeout: Maximum seconds to wait for the subprocess to complete
+            the full dialog. Exceeding this raises
+            :class:`ncp_langgraph.NCPTimeoutError`.
+
+    Returns:
+        A :class:`RunnerResult` with the graph's terminal output,
+        the full MCP ``structuredContent``, and the trace metadata
+        dict.
+
+    Raises:
+        NCPSubprocessError: Spawn failed, non-zero exit, malformed
+            JSON-RPC frames, or a JSON-RPC error response.
+        NCPInvocationError: The graph ran to a non-success terminal
+            (MCP `result.isError == true`).
+        NCPTimeoutError: The configured `timeout` was exceeded.
+        NCPAmbiguousToolError: `tools/list` returned multiple tools
+            and `tool_name` was not provided.
+        NotImplementedError: Always, in the v0.1.0.dev0 skeleton.
+            Real implementation lands in Phase 3A.3 PR C.
+    """
+    raise NotImplementedError(
+        "call_ncp_graph is a skeleton stub in ncp-langgraph v0.1.0.dev0. "
+        "The real implementation lands in Phase 3A.3 PR C. "
+        "See docs/LANGGRAPH_ADAPTER.md §3.3 + §5 for the locked "
+        "contract."
+    )

--- a/python/ncp-langgraph/src/ncp_langgraph/types.py
+++ b/python/ncp-langgraph/src/ncp_langgraph/types.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+
+"""Public types: exception hierarchy and `RunnerResult` dataclass.
+
+Per the locked design contract in `docs/LANGGRAPH_ADAPTER.md` (§6 + §7),
+these classes are part of the public API and are real types even in the
+package skeleton. Only the executable API paths in :mod:`node` and
+:mod:`subprocess_runner` raise `NotImplementedError` until PR C and
+PR D land the implementations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+class NCPError(Exception):
+    """Base class for all `ncp-langgraph` errors.
+
+    Catch this to handle any adapter-raised error without coupling to
+    the specific subclass.
+    """
+
+
+class NCPSubprocessError(NCPError):
+    """The `ncp-mcp-server` subprocess could not be driven successfully.
+
+    Raised on spawn failure, non-zero exit, malformed JSON-RPC frames,
+    or a JSON-RPC error response (MCP transport-level failure, not
+    NCP-graph-level failure -- see :class:`NCPInvocationError` for the
+    latter).
+    """
+
+
+class NCPInvocationError(NCPError):
+    """The NCP graph invocation completed but returned a non-success result.
+
+    Maps to MCP `result.isError == true`. The NCP graph ran to terminal
+    `Failure` or `LowConfidence` (or the adapter synthesized a Failure);
+    the subprocess itself behaved correctly. This carries trace metadata
+    so the caller can inspect what happened without re-running the
+    graph.
+
+    Attributes:
+        structured_content: The full MCP `structuredContent` object
+            returned by `tools/call`.
+        result_type: The NCP terminal result type, ``"Failure"`` or
+            ``"LowConfidence"``. Mirrors
+            `structured_content["result_type"]`.
+        trace_id: The NCP trace UUID for this invocation. Present even
+            when tracing is disabled.
+        trace_path: Absolute path to the JSONL trace file for this
+            invocation. `None` when tracing is disabled.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        structured_content: dict[str, Any],
+        result_type: str,
+        trace_id: str,
+        trace_path: str | None,
+    ) -> None:
+        super().__init__(message)
+        self.structured_content: dict[str, Any] = structured_content
+        self.result_type: str = result_type
+        self.trace_id: str = trace_id
+        self.trace_path: str | None = trace_path
+
+
+class NCPTimeoutError(NCPError):
+    """The subprocess did not complete within the configured timeout."""
+
+
+class NCPAmbiguousToolError(NCPError):
+    """`tools/list` returned multiple tools and no `tool_name` was given.
+
+    Raised during invocation when the configured `ncp-mcp-server`
+    exposes more than one tool and the caller did not disambiguate via
+    `tool_name=...`. With the v0.1.0 one-graph factory this should not
+    occur in normal use, but the guard remains for unexpected
+    `tools/list` responses and future multi-graph extensions.
+    """
+
+
+@dataclass(frozen=True)
+class RunnerResult:
+    """Result of a single `ncp-mcp-server` invocation.
+
+    Returned by :func:`call_ncp_graph`. :class:`NCPNode` internally
+    maps this into a LangGraph state-update dict; callers who use
+    `call_ncp_graph` directly get this dataclass back unchanged.
+
+    The dataclass is frozen to prevent reassignment of its top-level
+    fields. Nested JSON values remain normal Python objects.
+
+    Attributes:
+        output_json: The NCP graph's terminal output JSON value, taken
+            from the MCP `structuredContent.output_json` field.
+        structured_content: The full MCP `structuredContent` object, in
+            case the caller needs fields beyond `output_json` (e.g.
+            `result_type`).
+        trace: Trace metadata for this invocation. Keys:
+            ``"result_type"`` (str), ``"trace_id"`` (str), and
+            ``"trace_path"`` (str or None). `trace_path` is populated
+            only when the subprocess was configured with ``--trace-dir``.
+    """
+
+    output_json: Any
+    structured_content: dict[str, Any]
+    trace: dict[str, Any]

--- a/python/ncp-langgraph/tests/conftest.py
+++ b/python/ncp-langgraph/tests/conftest.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+
+"""Pytest configuration for ncp-langgraph tests.
+
+Skeleton stage: this file is intentionally empty. PR C will add fixtures
+here for the subprocess-runner integration tests, including the gated
+``NCP_MCP_SERVER`` env-var fixture that points pytest at a built
+``ncp-mcp-server`` binary on CI and on local developer machines that
+opt into integration tests.
+"""

--- a/python/ncp-langgraph/tests/test_smoke.py
+++ b/python/ncp-langgraph/tests/test_smoke.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+
+"""Skeleton smoke test for ncp-langgraph v0.1.0.dev0.
+
+Proves the import contract: the package imports cleanly, exposes
+``__version__``, exports every symbol listed in ``__all__``, and the
+non-executable public types (``RunnerResult`` and the exception
+hierarchy) are constructable / raisable as real Python objects.
+
+This file does NOT test the executable API paths
+(``NCPNode.from_subprocess``, ``NCPNode.__call__``,
+``call_ncp_graph``); those raise ``NotImplementedError`` in the
+skeleton, and the assertions that they raise (and later, that they
+work) belong with the PR C and PR D implementation tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, is_dataclass
+
+import pytest
+
+import ncp_langgraph
+
+
+def test_package_imports() -> None:
+    """`import ncp_langgraph` succeeds and exposes a non-empty version."""
+    assert isinstance(ncp_langgraph.__version__, str)
+    assert ncp_langgraph.__version__ != ""
+
+
+def test_version_matches_skeleton() -> None:
+    """`__version__` is the locked v0.1.0.dev0 skeleton string.
+
+    PR F flips this to ``"0.1.0"`` as part of the publish bump; this
+    assertion is the regression sentinel that prevents an accidental
+    version bump during PR B / C / D / E.
+    """
+    assert ncp_langgraph.__version__ == "0.1.0.dev0"
+
+
+def test_public_surface_exports() -> None:
+    """Every symbol in ``__all__`` is importable from the package root."""
+    for name in ncp_langgraph.__all__:
+        assert hasattr(ncp_langgraph, name), f"{name!r} listed in __all__ but missing"
+
+
+def test_runner_result_is_constructable() -> None:
+    """``RunnerResult`` is a real frozen dataclass, not a stub."""
+    assert is_dataclass(ncp_langgraph.RunnerResult)
+
+    result = ncp_langgraph.RunnerResult(
+        output_json={"ok": True},
+        structured_content={"output_json": {"ok": True}, "result_type": "Success"},
+        trace={"result_type": "Success", "trace_id": "test", "trace_path": None},
+    )
+    assert result.output_json == {"ok": True}
+    assert result.trace["trace_id"] == "test"
+
+    with pytest.raises(FrozenInstanceError):
+        result.output_json = {"ok": False}
+
+
+def test_exception_hierarchy() -> None:
+    """All four typed exceptions inherit from ``NCPError`` (and ``Exception``)."""
+    for exc_cls in (
+        ncp_langgraph.NCPSubprocessError,
+        ncp_langgraph.NCPInvocationError,
+        ncp_langgraph.NCPTimeoutError,
+        ncp_langgraph.NCPAmbiguousToolError,
+    ):
+        assert issubclass(exc_cls, ncp_langgraph.NCPError)
+        assert issubclass(exc_cls, Exception)
+
+
+def test_ncp_invocation_error_carries_trace_metadata() -> None:
+    """``NCPInvocationError`` carries the locked trace-metadata attributes."""
+    exc = ncp_langgraph.NCPInvocationError(
+        "graph returned Failure",
+        structured_content={"result_type": "Failure"},
+        result_type="Failure",
+        trace_id="abc-123",
+        trace_path="/tmp/abc-123.jsonl",
+    )
+    assert exc.result_type == "Failure"
+    assert exc.trace_id == "abc-123"
+    assert exc.trace_path == "/tmp/abc-123.jsonl"
+    assert exc.structured_content == {"result_type": "Failure"}


### PR DESCRIPTION
## Summary

- Establishes the `python/ncp-langgraph/` package scaffold so Phase 3A.3 PR C (subprocess runner) and PR D (`NCPNode` wrapper) can build on a frozen layout, lint/test pipeline, and CI gate.
- Public API surface is **stubbed** but importable: `NCPNode` + `call_ncp_graph` raise `NotImplementedError` naming PR D / PR C; `RunnerResult` dataclass and the five typed exceptions are **real** types, not stubs.
- New `langgraph-test` CI job (advisory only until PR G merges) runs ruff / mypy --strict / pytest / build / py.typed-in-wheel assertion / twine check on every PR.
- Locked dependency pin: `langgraph>=1.0.0,<2.0.0` (LangGraph 1.2.2 verified against the `StateGraph.add_node(name, callable)` pattern before lock).

See the commit message on `8b33056` for the full per-section breakdown (Package / Public API / Tests / CI / Hygiene / Verification).

## Test plan

- [x] `python -m ruff check .` — clean
- [x] `python -m ruff format --check .` — 6 files already formatted
- [x] `python -m mypy --strict src` — no issues in 4 source files
- [x] `python -m pytest` — 6 passed in 0.03s
- [x] `python -m build` — wheel + sdist built clean
- [x] `py.typed` marker present in built wheel
- [x] `python -m twine check dist/*` — wheel + sdist PASSED
- [x] `cargo fmt --all -- --check` — clean
- [x] YAML syntax parse on `.github/workflows/rust.yml` — valid
- [x] Simulated `git add -n` confirms no `__pycache__/`, no `.pyc`, no `dist/`, no `.mypy_cache/` would be staged
- [ ] CI: `langgraph-test` job goes green on this PR
- [ ] CI: existing required checks (DCO, fmt, clippy, test, mcp-smoke, validate, wasm-build) all green

## Refs

- Design contract: [`docs/LANGGRAPH_ADAPTER.md`](docs/LANGGRAPH_ADAPTER.md) (frozen in PR #40)
- Plan: Phase 3A.3 PR sequence (A done, B this PR, C-G upcoming)