### PR TITLE
feat(langgraph): real subprocess runner + tests (PR 3A.3-C)

### DIFF
--- a/python/ncp-langgraph/src/ncp_langgraph/__init__.py
+++ b/python/ncp-langgraph/src/ncp_langgraph/__init__.py
@@ -23,6 +23,7 @@ Public API:
   :class:`NCPTimeoutError`, :class:`NCPAmbiguousToolError`.
 """
 
+from ncp_langgraph._version import __version__
 from ncp_langgraph.node import NCPNode
 from ncp_langgraph.subprocess_runner import call_ncp_graph
 from ncp_langgraph.types import (
@@ -33,8 +34,6 @@ from ncp_langgraph.types import (
     NCPTimeoutError,
     RunnerResult,
 )
-
-__version__ = "0.1.0.dev0"
 
 __all__ = [
     "NCPNode",

--- a/python/ncp-langgraph/src/ncp_langgraph/_version.py
+++ b/python/ncp-langgraph/src/ncp_langgraph/_version.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+
+"""Single source of truth for `__version__`.
+
+This module is private (leading underscore). Both
+:mod:`ncp_langgraph.__init__` and
+:mod:`ncp_langgraph.subprocess_runner` import `__version__` from here
+so the version string has exactly one authoritative location and no
+circular-import risk arises from the public package surface importing
+from internal modules that also need the version.
+
+PR F bumps this from ``"0.1.0.dev0"`` to ``"0.1.0"`` as part of the
+publish ceremony (mirrors the bump in ``pyproject.toml``).
+"""
+
+__version__ = "0.1.0.dev0"

--- a/python/ncp-langgraph/src/ncp_langgraph/subprocess_runner.py
+++ b/python/ncp-langgraph/src/ncp_langgraph/subprocess_runner.py
@@ -11,18 +11,640 @@ Per the locked design contract in `docs/LANGGRAPH_ADAPTER.md` (§3.3 +
 §5), each :func:`call_ncp_graph` invocation spawns a fresh
 `ncp-mcp-server` subprocess, performs the four-frame dialog
 (``initialize`` -> ``notifications/initialized`` -> ``tools/list`` ->
-``tools/call``), closes stdin gracefully, and asserts a clean exit.
+``tools/call``), closes stdin gracefully, asserts a clean exit, and
+returns a :class:`RunnerResult`.
 
-Skeleton stage: this is a stub. The real implementation lands in
-Phase 3A.3 PR C.
+Lifecycle invariants:
+
+- **One subprocess per call.** No pool, no caching in v0.1.0.
+- **Cross-platform timeout** via `threading.Timer` (not `signal.SIGALRM`).
+- **stdio encoding is pinned to UTF-8.** MCP JSON is UTF-8 by spec;
+  relying on `locale.getencoding()` would silently differ across
+  platforms (Windows cp1252, Linux with `LC_ALL=C`, etc.).
+- **stderr is captured to a tempfile**, never `subprocess.PIPE`
+  (avoids the pipe-buffer deadlock hazard). The parent handle is
+  closed immediately after spawn; the child keeps its own dup'd FD.
+- **Post-dialog graceful-shutdown gate is mandatory.** Stdin is closed
+  and the subprocess is given up to 10s to exit; non-zero returncode
+  or graceful stall raises :class:`NCPSubprocessError`. This is the
+  regression sentinel for the rmcp tokio time-driver panic discovered
+  during Phase 3A.2-E real-host validation; mirrors
+  ``examples/mcp/ci_smoke.py``. The gate also runs on clean-protocol
+  error paths (ambiguous tool name, zero tools, unknown tool name) so
+  the regression sentinel is enforced uniformly.
+- **stderr lifecycle:** the tempfile is kept on disk only for
+  :class:`NCPSubprocessError`, :class:`NCPTimeoutError`, and unexpected
+  `BaseException`. Deleted on success, :class:`NCPInvocationError`
+  (graph-level outcome with its own trace file), and
+  :class:`NCPAmbiguousToolError` (clean protocol outcome). Empty logs
+  are deleted regardless.
+- **Strict JSON discipline.** `json.dumps(..., allow_nan=False)` is
+  used everywhere to reject NaN / Infinity / -Infinity early instead
+  of leaking non-standard values to the Rust side as a parse failure.
+- **Library-boundary type checks.** `arguments` must be a dict at
+  runtime, not just at type-check time; MCP `tools/call.arguments` is
+  specified as an object. `tools/list` entries are validated upfront
+  before any name-matching logic.
+- **Explicit type-boundary casts.** Values from `json.loads()` and
+  `.get()` are `Any` in the type system. After `isinstance(...)`
+  narrowing, dict-shaped values are widened to `dict[Any, Any]`, not
+  `dict[str, Any]`. The runner uses explicit :func:`typing.cast` at
+  every JSON-to-dict boundary to satisfy mypy --strict.
 """
 
 from __future__ import annotations
 
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
 from pathlib import Path
-from typing import Any
+from typing import IO, Any, cast
 
-from ncp_langgraph.types import RunnerResult
+from ncp_langgraph._version import __version__
+from ncp_langgraph.types import (
+    NCPAmbiguousToolError,
+    NCPInvocationError,
+    NCPSubprocessError,
+    NCPTimeoutError,
+    RunnerResult,
+)
+
+# ── constants ─────────────────────────────────────────────────────────
+
+_MCP_PROTOCOL_VERSION = "2025-11-25"
+_CLIENT_NAME = "ncp-langgraph"
+_POST_DIALOG_WAIT_SECONDS: float = 10.0
+_STDERR_TAIL_BYTES = 4096
+
+
+# ── small helpers ─────────────────────────────────────────────────────
+
+
+def _resolve_binary(binary: str | Path) -> Path:
+    """Resolve the `ncp-mcp-server` binary to a concrete file path.
+
+    For explicit paths (containing a path separator), the file must
+    exist AND be a regular file (rejects directories named
+    ``ncp-mcp-server``). On Windows, falls back to a ``.exe`` sibling
+    when the explicit path has no suffix.
+
+    For bare names, uses :func:`shutil.which` which already honors
+    ``PATHEXT`` on Windows (finds ``.exe`` automatically) and returns
+    only executable files (not directories).
+
+    Raises :class:`NCPSubprocessError` if no executable file is found.
+    """
+    p = Path(binary)
+    s = str(binary)
+    is_explicit_path = os.sep in s or "/" in s
+    if is_explicit_path:
+        if p.is_file():
+            return p.resolve()
+        if sys.platform == "win32" and p.suffix == "":
+            exe = p.with_suffix(".exe")
+            if exe.is_file():
+                return exe.resolve()
+        raise NCPSubprocessError(
+            f"binary not found (or not an executable file) at explicit path: {binary}"
+        )
+    resolved = shutil.which(s)
+    if resolved is None:
+        raise NCPSubprocessError(f"binary {binary!r} not found on PATH")
+    return Path(resolved)
+
+
+def _build_argv(
+    binary: Path,
+    graph: str | Path,
+    brick_dir: str | Path,
+    trace_dir: str | Path | None,
+) -> list[str]:
+    """Build the command-line argv for the `ncp-mcp-server` subprocess."""
+    argv = [
+        str(binary),
+        "--graph",
+        str(graph),
+        "--brick-dir",
+        str(brick_dir),
+    ]
+    if trace_dir is not None:
+        argv.extend(["--trace-dir", str(trace_dir)])
+    return argv
+
+
+def _read_stderr_tail(path: Path | None) -> str:
+    """Read the last `_STDERR_TAIL_BYTES` of a stderr log file.
+
+    Safe to call on missing/unreadable files: returns empty string.
+    Used to enrich exception messages with diagnostic context.
+    """
+    if path is None or not path.exists():
+        return ""
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return ""
+    tail = data[-_STDERR_TAIL_BYTES:]
+    return tail.decode("utf-8", errors="replace")
+
+
+# ── _DialogDriver ─────────────────────────────────────────────────────
+
+
+class _DialogDriver:
+    """Drives a single MCP stdio dialog against an `ncp-mcp-server` subprocess.
+
+    Owns one Popen handle for the duration of the dialog. Each method
+    handles a phase (`initialize`, `notifications/initialized`,
+    `tools/list`, `tools/call`) and maps I/O failures to the locked
+    typed exceptions:
+
+    - Timer-killed subprocess -> :class:`NCPTimeoutError`
+    - JSON-RPC error response or malformed shape -> :class:`NCPSubprocessError`
+      (with stderr tail in the message for diagnostics)
+
+    Does NOT own the subprocess lifecycle (spawn / cleanup); that's
+    `call_ncp_graph`'s job. The driver only reads/writes through the
+    pipes it was handed.
+    """
+
+    def __init__(
+        self,
+        proc: subprocess.Popen[str],
+        timeout_state: dict[str, bool],
+        stderr_log_path: Path,
+    ) -> None:
+        # Capture proc.stdin/stdout into locals BEFORE the None-check.
+        # Mutable attributes don't narrow safely in mypy because the
+        # attribute could be reassigned between the check and the
+        # next access; locals do narrow safely.
+        stdin = proc.stdin
+        stdout = proc.stdout
+        if stdin is None or stdout is None:
+            raise NCPSubprocessError("subprocess was not spawned with stdin/stdout pipes")
+        self._proc: subprocess.Popen[str] = proc
+        self._stdin: IO[str] = stdin
+        self._stdout: IO[str] = stdout
+        self._timeout_state = timeout_state
+        self._stderr_log_path = stderr_log_path
+
+    def _stderr_tail(self) -> str:
+        return _read_stderr_tail(self._stderr_log_path)
+
+    def _send(self, frame: dict[str, Any]) -> None:
+        """Write one JSON-RPC frame to subprocess stdin.
+
+        Strict JSON: NaN / Infinity / -Infinity are rejected here
+        (`allow_nan=False`) so non-standard values fail with a clean
+        Python-side error rather than leaking to the Rust parser.
+
+        Raises:
+            NCPSubprocessError: frame is not JSON-serializable (incl.
+                NaN/Infinity), or stdin write/flush fails for a reason
+                other than timeout.
+            NCPTimeoutError: write failure during a timer-killed state.
+        """
+        try:
+            line = json.dumps(frame, allow_nan=False) + "\n"
+        except (TypeError, ValueError) as e:
+            raise NCPSubprocessError(f"failed to serialize MCP frame: {e}") from e
+        try:
+            self._stdin.write(line)
+            self._stdin.flush()
+        except (BrokenPipeError, OSError) as e:
+            if self._timeout_state["fired"]:
+                raise NCPTimeoutError(
+                    f"timeout exceeded while writing JSON-RPC frame; "
+                    f"subprocess was killed by timer.\n"
+                    f"stderr tail:\n{self._stderr_tail()}"
+                ) from e
+            raise NCPSubprocessError(
+                f"failed writing JSON-RPC frame to subprocess stdin: {e}\n"
+                f"stderr tail:\n{self._stderr_tail()}"
+            ) from e
+
+    def _read_response(self, expected_id: int, context: str) -> dict[str, Any]:
+        """Read one JSON-RPC response and assert envelope shape.
+
+        Returns the parsed response dict on success. Raises
+        :class:`NCPSubprocessError` on any envelope violation
+        (jsonrpc!='2.0', `error` field present, id mismatch, non-JSON
+        line, non-dict body, non-UTF-8 bytes). Raises
+        :class:`NCPTimeoutError` if the timer fired during the read.
+        """
+        try:
+            line = self._stdout.readline()
+        except UnicodeDecodeError as e:
+            raise NCPSubprocessError(
+                f"failed decoding {context} response as UTF-8: {e}\n"
+                f"stderr tail:\n{self._stderr_tail()}"
+            ) from e
+        except OSError as e:
+            if self._timeout_state["fired"]:
+                raise NCPTimeoutError(
+                    f"timeout exceeded while reading {context} response; "
+                    f"subprocess was killed by timer.\n"
+                    f"stderr tail:\n{self._stderr_tail()}"
+                ) from e
+            raise NCPSubprocessError(
+                f"failed reading {context} response from subprocess stdout: "
+                f"{e}\nstderr tail:\n{self._stderr_tail()}"
+            ) from e
+        if not line:
+            if self._timeout_state["fired"]:
+                raise NCPTimeoutError(
+                    f"timeout exceeded waiting for {context} response; "
+                    f"subprocess was killed by timer.\n"
+                    f"stderr tail:\n{self._stderr_tail()}"
+                )
+            raise NCPSubprocessError(
+                f"subprocess closed stdout before sending {context} response.\n"
+                f"stderr tail:\n{self._stderr_tail()}"
+            )
+        try:
+            resp_raw = json.loads(line)
+        except json.JSONDecodeError as e:
+            raise NCPSubprocessError(
+                f"{context} response is not valid JSON: {e}; line: {line!r}\n"
+                f"stderr tail:\n{self._stderr_tail()}"
+            ) from e
+        if not isinstance(resp_raw, dict):
+            raise NCPSubprocessError(
+                f"{context} response is not a JSON object: {resp_raw!r}\n"
+                f"stderr tail:\n{self._stderr_tail()}"
+            )
+        # isinstance narrows Any -> dict[Any, Any]; we want dict[str, Any]
+        # for the rest of the function. The cast is the standard mypy
+        # strict pattern at JSON-to-typed-dict boundaries.
+        resp = cast(dict[str, Any], resp_raw)
+        if resp.get("jsonrpc") != "2.0":
+            raise NCPSubprocessError(
+                f"{context} response missing jsonrpc='2.0': {resp}\n"
+                f"stderr tail:\n{self._stderr_tail()}"
+            )
+        if "error" in resp and resp["error"] is not None:
+            raise NCPSubprocessError(
+                f"{context} returned JSON-RPC error: {resp['error']}\n"
+                f"stderr tail:\n{self._stderr_tail()}"
+            )
+        if resp.get("id") != expected_id:
+            raise NCPSubprocessError(
+                f"{context} response id mismatch (expected {expected_id}): "
+                f"{resp}\nstderr tail:\n{self._stderr_tail()}"
+            )
+        return resp
+
+    def initialize(self) -> None:
+        """Send the `initialize` request and validate the response."""
+        self._send(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": _MCP_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": _CLIENT_NAME,
+                        "version": __version__,
+                    },
+                },
+            }
+        )
+        resp = self._read_response(expected_id=1, context="initialize")
+        if not isinstance(resp.get("result"), dict):
+            raise NCPSubprocessError(
+                f"initialize response missing result object: {resp}\n"
+                f"stderr tail:\n{self._stderr_tail()}"
+            )
+
+    def initialized(self) -> None:
+        """Send the `notifications/initialized` notification (no response)."""
+        self._send(
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+            }
+        )
+
+    def list_tools(self) -> list[Any]:
+        """Send `tools/list` and return the tools array from the response.
+
+        Returns `list[Any]` not `list[dict[str, Any]]` because individual
+        entries are not validated here. `_resolve_tool_name` performs
+        the per-entry validation, which is the correct boundary for
+        that work and lets this method stay honest about what came
+        off the wire.
+        """
+        self._send(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/list",
+                "params": {},
+            }
+        )
+        resp = self._read_response(expected_id=2, context="tools/list")
+        result = resp.get("result")
+        if not isinstance(result, dict):
+            raise NCPSubprocessError(
+                f"tools/list response missing result object: {resp}\n"
+                f"stderr tail:\n{self._stderr_tail()}"
+            )
+        tools = result.get("tools")
+        if not isinstance(tools, list):
+            raise NCPSubprocessError(
+                f"tools/list result.tools is not a list: {result}\n"
+                f"stderr tail:\n{self._stderr_tail()}"
+            )
+        # isinstance narrows Any -> list[Any] directly; no cast needed.
+        return tools
+
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Send `tools/call` and return the result object."""
+        self._send(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": name,
+                    "arguments": arguments,
+                },
+            }
+        )
+        resp = self._read_response(expected_id=3, context="tools/call")
+        result = resp.get("result")
+        if not isinstance(result, dict):
+            raise NCPSubprocessError(
+                f"tools/call response missing result object: {resp}\n"
+                f"stderr tail:\n{self._stderr_tail()}"
+            )
+        # cast: narrowed dict[Any, Any] -> declared dict[str, Any].
+        return cast(dict[str, Any], result)
+
+
+# ── result validation / extraction helpers ────────────────────────────
+
+
+def _resolve_tool_name(
+    tools: list[Any],
+    requested_name: str | None,
+) -> str:
+    """Pick the MCP tool name to invoke.
+
+    Validates every tool entry from `tools/list` upfront before any
+    name-matching logic. `tools/list` is a protocol boundary; silently
+    ignoring malformed entries would let a server-side bug slip past
+    as if it were clean data.
+
+    Accepts `list[Any]` because :meth:`_DialogDriver.list_tools`
+    returns entries without per-entry validation; this function is
+    where that validation happens.
+
+    If `requested_name` is provided, verify it appears in the validated
+    `tools` array and return it. Otherwise auto-derive: exactly one
+    tool -> that tool's name; zero tools or multiple tools -> raise.
+
+    Raises:
+        NCPAmbiguousToolError: multiple tools, no `requested_name`.
+        NCPSubprocessError: zero tools, requested name not in list,
+            or any tool entry is not a `{name: string, ...}` object.
+    """
+    names: list[str] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            raise NCPSubprocessError(f"tools/list returned non-object tool entry: {tool!r}")
+        name = tool.get("name")
+        if not isinstance(name, str):
+            raise NCPSubprocessError(f"tools/list returned a tool with non-string name: {name!r}")
+        names.append(name)
+
+    if requested_name is not None:
+        if requested_name not in names:
+            raise NCPSubprocessError(
+                f"requested tool_name={requested_name!r} not in tools/list; "
+                f"available tools: {names}"
+            )
+        return requested_name
+    if len(names) == 0:
+        raise NCPSubprocessError("tools/list returned zero tools; cannot auto-derive tool_name")
+    if len(names) > 1:
+        raise NCPAmbiguousToolError(
+            f"tools/list returned multiple tools ({names}); "
+            f"pass tool_name=... to NCPNode.from_subprocess or call_ncp_graph "
+            f"to disambiguate"
+        )
+    return names[0]
+
+
+def _validate_call_result_shape(result: dict[str, Any]) -> dict[str, Any]:
+    """Validate `tools/call` result + `structuredContent` shape.
+
+    Returns the `structuredContent` dict on success. Raises
+    :class:`NCPSubprocessError` on any shape violation. Uses
+    key-presence checks (`in`) for required fields so JSON null is
+    distinguished from a missing key.
+    """
+    if "isError" not in result:
+        raise NCPSubprocessError(f"tools/call result missing 'isError' field: {result}")
+    if not isinstance(result["isError"], bool):
+        raise NCPSubprocessError(f"tools/call result.isError is not a bool: {result['isError']!r}")
+    if "structuredContent" not in result:
+        raise NCPSubprocessError(f"tools/call result missing 'structuredContent' field: {result}")
+    sc_raw = result["structuredContent"]
+    if not isinstance(sc_raw, dict):
+        raise NCPSubprocessError(f"tools/call result.structuredContent is not a dict: {sc_raw!r}")
+    # cast: narrowed dict[Any, Any] -> declared dict[str, Any].
+    sc = cast(dict[str, Any], sc_raw)
+    for required in (
+        "result_type",
+        "trace_id",
+        "trace_path",
+        "output_json",
+        "terminal_results",
+    ):
+        if required not in sc:
+            raise NCPSubprocessError(f"structuredContent missing required key {required!r}: {sc}")
+    if not isinstance(sc["result_type"], str):
+        raise NCPSubprocessError(
+            f"structuredContent.result_type is not a string: {sc['result_type']!r}"
+        )
+    allowed_result_types = {"Success", "LowConfidence", "Failure"}
+    if sc["result_type"] not in allowed_result_types:
+        raise NCPSubprocessError(
+            f"structuredContent.result_type is not one of "
+            f"{sorted(allowed_result_types)}: {sc['result_type']!r}"
+        )
+    if result["isError"] is True and sc["result_type"] == "Success":
+        raise NCPSubprocessError(
+            "tools/call result isError=true but structuredContent.result_type='Success'"
+        )
+    if result["isError"] is False and sc["result_type"] != "Success":
+        raise NCPSubprocessError(
+            f"tools/call result isError=false but structuredContent.result_type="
+            f"{sc['result_type']!r}"
+        )
+    if not isinstance(sc["trace_id"], str):
+        raise NCPSubprocessError(f"structuredContent.trace_id is not a string: {sc['trace_id']!r}")
+    if sc["trace_path"] is not None and not isinstance(sc["trace_path"], str):
+        raise NCPSubprocessError(
+            f"structuredContent.trace_path is not a string or null: {sc['trace_path']!r}"
+        )
+    if not isinstance(sc["terminal_results"], list):
+        raise NCPSubprocessError(
+            f"structuredContent.terminal_results is not a list: {sc['terminal_results']!r}"
+        )
+    return sc
+
+
+# ── cleanup helpers ───────────────────────────────────────────────────
+
+
+def _close_stdin_and_assert_clean_exit(
+    proc: subprocess.Popen[str],
+    stderr_log_path: Path,
+    timeout_state: dict[str, bool],
+) -> None:
+    """Close stdin and assert the subprocess exits 0 within the post-dialog wait.
+
+    Regression sentinel for the rmcp tokio time-driver panic discovered
+    in Phase 3A.2-E real-host validation: rmcp's drain path uses
+    `tokio::time::timeout`, which panics if the time driver is not
+    enabled. The panic only fires after stdin EOF, AFTER the last
+    response has been sent. Dialog-only success assertions would miss
+    it. This gate catches it.
+
+    `timeout_state` is consulted on every failure path: if the global
+    `threading.Timer` fired during graceful shutdown (the killed
+    subprocess could surface as a non-zero returncode or a
+    `TimeoutExpired` on `proc.wait`), the failure is mapped to
+    :class:`NCPTimeoutError` instead of :class:`NCPSubprocessError`.
+
+    Raises:
+        NCPTimeoutError: timer fired during graceful shutdown.
+        NCPSubprocessError: graceful shutdown stalled past
+            `_POST_DIALOG_WAIT_SECONDS` (timer did not fire), or
+            returncode != 0 (timer did not fire).
+    """
+    if proc.stdin is not None and not proc.stdin.closed:
+        try:
+            proc.stdin.close()
+        except (BrokenPipeError, OSError):
+            pass
+    try:
+        returncode = proc.wait(timeout=_POST_DIALOG_WAIT_SECONDS)
+    except subprocess.TimeoutExpired as e:
+        if timeout_state["fired"]:
+            raise NCPTimeoutError(
+                f"timeout exceeded during graceful shutdown; "
+                f"subprocess was killed by timer.\n"
+                f"stderr tail:\n{_read_stderr_tail(stderr_log_path)}"
+            ) from e
+        raise NCPSubprocessError(
+            f"subprocess did not exit within {_POST_DIALOG_WAIT_SECONDS}s "
+            f"after stdin close (graceful shutdown stalled).\n"
+            f"stderr tail:\n{_read_stderr_tail(stderr_log_path)}"
+        ) from e
+    if returncode != 0:
+        if timeout_state["fired"]:
+            raise NCPTimeoutError(
+                f"timeout exceeded during graceful shutdown; "
+                f"subprocess was killed by timer "
+                f"(returncode={returncode}).\n"
+                f"stderr tail:\n{_read_stderr_tail(stderr_log_path)}"
+            )
+        raise NCPSubprocessError(
+            f"subprocess exited non-zero after graceful shutdown: "
+            f"returncode={returncode}.\n"
+            f"stderr tail:\n{_read_stderr_tail(stderr_log_path)}"
+        )
+
+
+def _finally_graceful_cleanup(proc: subprocess.Popen[str]) -> None:
+    """Best-effort cleanup for the `finally` block.
+
+    Tries graceful close first (stdin close + wait up to 10s); only
+    kills if graceful exit stalls. Safe to call on already-exited
+    subprocesses (no-op). **Never raises** -- escaping exceptions here
+    would mask the caller's `raised_exception` and skip
+    `_cleanup_stderr_log`. Does NOT assert returncode; the regression
+    sentinel is enforced only by `_close_stdin_and_assert_clean_exit`.
+    """
+    if proc.poll() is not None:
+        return
+    if proc.stdin is not None and not proc.stdin.closed:
+        try:
+            proc.stdin.close()
+        except (BrokenPipeError, OSError):
+            pass
+    # First wait: graceful exit attempt. Catch BOTH OSError and
+    # TimeoutExpired so this helper truly never raises -- an OSError
+    # leaking here would mask raised_exception and skip the stderr
+    # log cleanup in the caller's finally block.
+    try:
+        proc.wait(timeout=_POST_DIALOG_WAIT_SECONDS)
+        return
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    # Graceful wait stalled; escalate to kill. `kill()` raises OSError
+    # only if the process is already gone or unreachable -- in either
+    # case there's nothing left to wait for. `wait()` after kill() can
+    # still raise TimeoutExpired (rare: zombie not yet reaped); catch
+    # both so this helper truly never raises.
+    try:
+        proc.kill()
+    except OSError:
+        return
+    try:
+        proc.wait(timeout=5)
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+
+def _cleanup_stderr_log(
+    stderr_log_path: Path | None,
+    raised_exception: BaseException | None,
+) -> None:
+    """Delete or keep the stderr tempfile per the locked lifecycle.
+
+    Keep on: :class:`NCPSubprocessError`, :class:`NCPTimeoutError`,
+    unexpected `BaseException`.
+    Delete on: success (`raised_exception is None`),
+    :class:`NCPInvocationError`, :class:`NCPAmbiguousToolError`.
+
+    Override: an empty (0-byte) log is deleted regardless of exception
+    type, since an empty log has no diagnostic value.
+    """
+    if stderr_log_path is None:
+        return
+    if raised_exception is None:
+        keep = False
+    elif isinstance(raised_exception, (NCPSubprocessError, NCPTimeoutError)):
+        keep = True
+    elif isinstance(raised_exception, (NCPInvocationError, NCPAmbiguousToolError)):
+        keep = False
+    else:
+        keep = True
+    if keep and stderr_log_path.exists():
+        try:
+            if stderr_log_path.stat().st_size == 0:
+                keep = False
+        except OSError:
+            pass
+    if keep:
+        return
+    try:
+        stderr_log_path.unlink()
+    except OSError:
+        pass
+
+
+# ── public call_ncp_graph(...) ────────────────────────────────────────
 
 
 def call_ncp_graph(
@@ -48,7 +670,9 @@ def call_ncp_graph(
         brick_dir: Path to the directory containing the graph's brick
             WASM artifacts. Forwarded to `ncp-mcp-server --brick-dir`.
         arguments: The arguments object passed to MCP `tools/call`.
-            This is the input the NCP graph sees as its root input.
+            Must be a dict (MCP spec: tools/call.arguments is an
+            object) and strict-JSON-serializable (NaN / Infinity
+            rejected via `allow_nan=False`).
         trace_dir: If set, forwarded to `ncp-mcp-server --trace-dir`.
             Causes the subprocess to write a JSONL trace file per
             invocation. When `None`, tracing is disabled and
@@ -71,18 +695,145 @@ def call_ncp_graph(
 
     Raises:
         NCPSubprocessError: Spawn failed, non-zero exit, malformed
-            JSON-RPC frames, or a JSON-RPC error response.
+            JSON-RPC frames, a JSON-RPC error response, `arguments`
+            is not a dict, or `arguments` contains non-JSON values.
         NCPInvocationError: The graph ran to a non-success terminal
             (MCP `result.isError == true`).
         NCPTimeoutError: The configured `timeout` was exceeded.
         NCPAmbiguousToolError: `tools/list` returned multiple tools
             and `tool_name` was not provided.
-        NotImplementedError: Always, in the v0.1.0.dev0 skeleton.
-            Real implementation lands in Phase 3A.3 PR C.
     """
-    raise NotImplementedError(
-        "call_ncp_graph is a skeleton stub in ncp-langgraph v0.1.0.dev0. "
-        "The real implementation lands in Phase 3A.3 PR C. "
-        "See docs/LANGGRAPH_ADAPTER.md §3.3 + §5 for the locked "
-        "contract."
+    # ── Pre-flight: arguments must be a dict and strict-JSON-serializable ──
+    # MCP `tools/call.arguments` is specified as an object. Catch
+    # list/str/None/number at the Python boundary so users get a clean
+    # precondition error instead of a confusing JSON-RPC rejection
+    # from the Rust side.
+    if not isinstance(arguments, dict):
+        raise NCPSubprocessError(
+            f"MCP tools/call arguments must be a dict/object, got {type(arguments).__name__}"
+        )
+    try:
+        json.dumps(arguments, allow_nan=False)
+    except (TypeError, ValueError) as e:
+        raise NCPSubprocessError(
+            f"failed to serialize MCP tools/call arguments to JSON: {e}"
+        ) from e
+
+    # ── Resolve binary + build argv ──
+    resolved_binary = _resolve_binary(binary)
+    argv = _build_argv(resolved_binary, graph, brick_dir, trace_dir)
+
+    # ── Open stderr tempfile (NOT subprocess.PIPE) ──
+    stderr_log = tempfile.NamedTemporaryFile(
+        mode="wb",
+        prefix="ncp-langgraph-stderr-",
+        suffix=".log",
+        delete=False,
     )
+    stderr_log_path = Path(stderr_log.name)
+
+    proc: subprocess.Popen[str] | None = None
+    timer: threading.Timer | None = None
+    timeout_state: dict[str, bool] = {"fired": False}
+    raised_exception: BaseException | None = None
+
+    try:
+        # ── Spawn subprocess ──
+        # encoding="utf-8" pins stdio to UTF-8 across platforms (MCP
+        # JSON is UTF-8 by spec; locale-default would silently differ
+        # on Windows or under `LC_ALL=C`).
+        try:
+            proc = subprocess.Popen(
+                argv,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=stderr_log,
+                text=True,
+                encoding="utf-8",
+                bufsize=1,
+            )
+        except (FileNotFoundError, PermissionError, OSError) as e:
+            raise NCPSubprocessError(
+                f"failed to spawn ncp-mcp-server subprocess ({resolved_binary}): {e}"
+            ) from e
+        finally:
+            try:
+                stderr_log.close()
+            except OSError:
+                pass
+
+        # ── Post-spawn narrowing guard ──
+        # The spawn block declared `proc` as `Popen[str] | None`; from
+        # here on the successful path it MUST be non-None. The explicit
+        # guard removes mypy's narrowing brittleness across versions
+        # and documents the invariant at the language level. `proc`
+        # remains the optional outer variable for the finally block;
+        # `proc_handle` is the non-None reference used by the dialog
+        # and regression-sentinel calls.
+        if proc is None:
+            raise NCPSubprocessError(
+                "failed to spawn ncp-mcp-server subprocess: no process handle returned"
+            )
+        proc_handle: subprocess.Popen[str] = proc
+
+        # ── Setup timeout ──
+        captured_proc: subprocess.Popen[str] = proc_handle
+
+        def on_timeout() -> None:
+            timeout_state["fired"] = True
+            try:
+                captured_proc.kill()
+            except OSError:
+                pass
+
+        timer = threading.Timer(timeout, on_timeout)
+        timer.daemon = True
+        timer.start()
+
+        # ── Drive the MCP dialog ──
+        driver = _DialogDriver(proc_handle, timeout_state, stderr_log_path)
+        driver.initialize()
+        driver.initialized()
+        tools = driver.list_tools()
+
+        # ── Resolve tool name; run regression sentinel before raising ──
+        try:
+            resolved_name = _resolve_tool_name(tools, tool_name)
+        except (NCPAmbiguousToolError, NCPSubprocessError):
+            _close_stdin_and_assert_clean_exit(proc_handle, stderr_log_path, timeout_state)
+            raise
+
+        call_result = driver.call_tool(resolved_name, arguments)
+
+        # ── Regression-sentinel: assert clean post-dialog exit ──
+        _close_stdin_and_assert_clean_exit(proc_handle, stderr_log_path, timeout_state)
+
+        # ── Extract result OR raise NCPInvocationError ──
+        sc = _validate_call_result_shape(call_result)
+        if call_result["isError"] is True:
+            raise NCPInvocationError(
+                f"NCP graph returned non-success terminal: {sc['result_type']}",
+                structured_content=sc,
+                result_type=sc["result_type"],
+                trace_id=sc["trace_id"],
+                trace_path=sc["trace_path"],
+            )
+        return RunnerResult(
+            output_json=sc["output_json"],
+            structured_content=sc,
+            trace={
+                "result_type": sc["result_type"],
+                "trace_id": sc["trace_id"],
+                "trace_path": sc["trace_path"],
+            },
+        )
+
+    except BaseException as exc:
+        raised_exception = exc
+        raise
+    finally:
+        if timer is not None:
+            timer.cancel()
+        if proc is not None:
+            _finally_graceful_cleanup(proc)
+        _cleanup_stderr_log(stderr_log_path, raised_exception)

--- a/python/ncp-langgraph/tests/conftest.py
+++ b/python/ncp-langgraph/tests/conftest.py
@@ -1,11 +1,103 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Fabio Marcello Salvadori
 
-"""Pytest configuration for ncp-langgraph tests.
+"""Pytest configuration + fixtures for ncp-langgraph tests.
 
-Skeleton stage: this file is intentionally empty. PR C will add fixtures
-here for the subprocess-runner integration tests, including the gated
-``NCP_MCP_SERVER`` env-var fixture that points pytest at a built
-``ncp-mcp-server`` binary on CI and on local developer machines that
-opt into integration tests.
+Fixtures:
+
+- :func:`repo_root` -- absolute Path to the NCP workspace root,
+  derived from this test file's location (four directories up).
+- :func:`echo_pipeline_graph` -- absolute Path to the bundled
+  echo-pipeline graph YAML at
+  ``examples/graphs/echo-pipeline/graph.yaml``.
+- :func:`brick_dir` -- absolute Path to the bundled bricks directory
+  at ``examples/bricks/``.
+- :func:`mcp_server_binary` -- absolute Path to a built
+  ``ncp-mcp-server`` binary, resolved from the ``NCP_MCP_SERVER``
+  environment variable. Tests requiring a real subprocess gate on
+  this fixture and skip cleanly when the env var is absent.
+
+Integration tests gate on ``mcp_server_binary``; CI sets the env var
+after building the release binary (see the ``langgraph-test`` job in
+``.github/workflows/rust.yml``). Local developers can either build
+the binary and export the env var, or skip the gated tests.
 """
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _skip_or_fail_missing(message: str) -> None:
+    """Skip when integration is not configured; fail when it is.
+
+    Integration tests are gated on ``NCP_MCP_SERVER``. When the env
+    var is absent, missing example paths are a "this developer hasn't
+    set up integration tests yet" case -- skip cleanly. When the env
+    var IS set (CI, or a developer running integration tests), missing
+    example paths are a "the gated tests SHOULD run but a fixture path
+    is broken" case -- fail loudly so the misconfiguration is visible
+    in the CI report instead of silently skipping every integration
+    test.
+    """
+    if os.environ.get("NCP_MCP_SERVER"):
+        pytest.fail(message)
+    pytest.skip(message)
+
+
+@pytest.fixture(scope="session")
+def repo_root() -> Path:
+    """Absolute Path to the NCP workspace root.
+
+    Derived from this test file's location: tests/conftest.py is at
+    ``<root>/python/ncp-langgraph/tests/conftest.py``, so four parents
+    up gives the workspace root.
+    """
+    return Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture(scope="session")
+def echo_pipeline_graph(repo_root: Path) -> Path:
+    """Absolute Path to the bundled echo-pipeline graph YAML."""
+    path = repo_root / "examples" / "graphs" / "echo-pipeline" / "graph.yaml"
+    if not path.is_file():
+        _skip_or_fail_missing(f"echo-pipeline graph not found at {path}")
+    return path
+
+
+@pytest.fixture(scope="session")
+def brick_dir(repo_root: Path) -> Path:
+    """Absolute Path to the bundled bricks directory."""
+    path = repo_root / "examples" / "bricks"
+    if not path.is_dir():
+        _skip_or_fail_missing(f"bricks directory not found at {path}")
+    return path
+
+
+@pytest.fixture(scope="session")
+def mcp_server_binary() -> Path:
+    """Absolute Path to a built ``ncp-mcp-server`` binary.
+
+    Resolved from the ``NCP_MCP_SERVER`` environment variable. Tests
+    requiring a real subprocess depend on this fixture and skip
+    cleanly when the env var is absent. CI sets the variable in the
+    ``langgraph-test`` workflow job after building the release binary.
+    """
+    raw = os.environ.get("NCP_MCP_SERVER")
+    if not raw:
+        pytest.skip(
+            "NCP_MCP_SERVER env var not set; gated integration test "
+            "(set it to the absolute path of a built ncp-mcp-server "
+            "binary to run integration tests locally)"
+        )
+    path = Path(raw).expanduser().resolve()
+    if not path.is_file():
+        # Once NCP_MCP_SERVER is set, integration is explicitly
+        # configured. A bad path is misconfiguration that should fail
+        # CI, not silently skip every integration test. Same discipline
+        # applied to echo_pipeline_graph and brick_dir.
+        pytest.fail(f"NCP_MCP_SERVER points to {path} but it's not a file")
+    return path

--- a/python/ncp-langgraph/tests/test_subprocess_runner.py
+++ b/python/ncp-langgraph/tests/test_subprocess_runner.py
@@ -1,0 +1,1258 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+
+"""Tests for :mod:`ncp_langgraph.subprocess_runner`.
+
+Two layers:
+
+- **Unit tests with mocked Popen.** Patch :func:`subprocess.Popen` and
+  :func:`ncp_langgraph.subprocess_runner._resolve_binary` so the dialog
+  driver, validation logic, and exception mapping can be tested
+  without spawning a real binary. Always run.
+- **Integration tests against a real `ncp-mcp-server`.** Gated on the
+  ``mcp_server_binary`` fixture (in turn gated on the
+  ``NCP_MCP_SERVER`` env var); skipped cleanly when the env var is
+  absent. CI exports the env var after building the release binary.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import ncp_langgraph
+from ncp_langgraph.subprocess_runner import call_ncp_graph
+
+# ── test helpers ──────────────────────────────────────────────────────
+
+
+DEFAULT_TOOL_NAME = "test-tool"
+
+
+def _success_result(
+    output_json: Any = None,
+    trace_id: str = "trace-uuid",
+    trace_path: str | None = None,
+) -> dict[str, Any]:
+    """Build a `tools/call` result for an isError=false, Success terminal."""
+    if output_json is None:
+        output_json = {"echoed": "ok"}
+    return {
+        "isError": False,
+        "structuredContent": {
+            "result_type": "Success",
+            "output_json": output_json,
+            "trace_id": trace_id,
+            "trace_path": trace_path,
+            "terminal_results": [],
+        },
+        "content": [],
+    }
+
+
+def _failure_result(
+    result_type: str = "Failure",
+    output_json: Any = None,
+    trace_id: str = "trace-uuid",
+    trace_path: str | None = None,
+) -> dict[str, Any]:
+    """Build a `tools/call` result for an isError=true terminal."""
+    return {
+        "isError": True,
+        "structuredContent": {
+            "result_type": result_type,
+            "output_json": output_json,
+            "trace_id": trace_id,
+            "trace_path": trace_path,
+            "terminal_results": [],
+        },
+        "content": [],
+    }
+
+
+def _make_init_response() -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "test", "version": "0.0.0"},
+        },
+    }
+
+
+def _make_tools_list_response(tools: list[Any] | None = None) -> dict[str, Any]:
+    if tools is None:
+        tools = [{"name": DEFAULT_TOOL_NAME, "description": "test"}]
+    return {"jsonrpc": "2.0", "id": 2, "result": {"tools": tools}}
+
+
+def _make_call_response(result: dict[str, Any] | None = None) -> dict[str, Any]:
+    if result is None:
+        result = _success_result()
+    return {"jsonrpc": "2.0", "id": 3, "result": result}
+
+
+def _frames(
+    init: dict[str, Any] | None = None,
+    tools_list: dict[str, Any] | None = None,
+    call: dict[str, Any] | None = None,
+) -> list[str]:
+    """Build the three response frames the runner reads, in order."""
+    frames: list[dict[str, Any]] = [
+        init if init is not None else _make_init_response(),
+        tools_list if tools_list is not None else _make_tools_list_response(),
+        call if call is not None else _make_call_response(),
+    ]
+    return [json.dumps(f) + "\n" for f in frames]
+
+
+class _FakeStdin:
+    """Test double for the subprocess stdin pipe."""
+
+    def __init__(self) -> None:
+        self.writes: list[str] = []
+        self.closed = False
+
+    def write(self, data: str) -> int:
+        if self.closed:
+            raise OSError("write to closed stdin")
+        self.writes.append(data)
+        return len(data)
+
+    def flush(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeStdout:
+    """Test double for the subprocess stdout pipe."""
+
+    def __init__(self, lines: list[str]) -> None:
+        self._iter = iter(lines)
+
+    def readline(self) -> str:
+        try:
+            return next(self._iter)
+        except StopIteration:
+            return ""
+
+
+class _FakePopen:
+    """Test double for subprocess.Popen[str].
+
+    Configured per-test with stdout response frames, returncode, and
+    optional wait/kill side effects. ``wait_side_effect`` runs at the
+    start of every ``wait()`` call -- used for timer-triggering tests
+    where the timer must fire mid-wait.
+    """
+
+    def __init__(
+        self,
+        stdout_lines: list[str],
+        returncode: int = 0,
+        wait_timeout_first: bool = False,
+        wait_side_effect: Callable[[], None] | None = None,
+    ) -> None:
+        self._returncode = returncode
+        self._wait_timeout_first = wait_timeout_first
+        self._wait_side_effect = wait_side_effect
+        self._exited = False
+        self.stdin: _FakeStdin | None = _FakeStdin()
+        self.stdout: _FakeStdout = _FakeStdout(stdout_lines)
+        self.kill_called = False
+        self.argv: list[str] | None = None
+        self.popen_kwargs: dict[str, Any] = {}
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self._wait_side_effect is not None:
+            self._wait_side_effect()
+        if self._wait_timeout_first:
+            self._wait_timeout_first = False
+            raise subprocess.TimeoutExpired(cmd=[], timeout=timeout or 0.0)
+        self._exited = True
+        return self._returncode
+
+    def poll(self) -> int | None:
+        return self._returncode if self._exited else None
+
+    def kill(self) -> None:
+        self.kill_called = True
+        self._exited = True
+
+
+class _ImmediateTimer:
+    """Test double for threading.Timer that fires the callback on start()."""
+
+    daemon = True
+
+    def __init__(self, _interval: float, function: Callable[[], None]) -> None:
+        self._function = function
+
+    def start(self) -> None:
+        self._function()
+
+    def cancel(self) -> None:
+        pass
+
+
+class _CapturingTimer:
+    """Test double for threading.Timer that captures the callback without
+    firing it. Tests trigger the callback manually via the class-level
+    ``last_callback`` slot.
+    """
+
+    daemon = True
+    last_callback: Callable[[], None] | None = None
+
+    def __init__(self, _interval: float, function: Callable[[], None]) -> None:
+        _CapturingTimer.last_callback = function
+
+    def start(self) -> None:
+        pass
+
+    def cancel(self) -> None:
+        pass
+
+
+def _patch_popen_and_binary(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_popen: _FakePopen,
+    binary_path: Path | None = None,
+) -> _FakePopen:
+    """Patch subprocess.Popen + _resolve_binary so the test never
+    touches the filesystem or spawns a real subprocess.
+    """
+    if binary_path is None:
+        binary_path = Path("/fake/ncp-mcp-server")
+
+    def fake_resolve_binary(_binary: Any) -> Path:
+        return binary_path
+
+    def fake_factory(*args: Any, **kwargs: Any) -> _FakePopen:
+        if args:
+            fake_popen.argv = list(args[0])
+        elif "args" in kwargs:
+            fake_popen.argv = list(kwargs["args"])
+        fake_popen.popen_kwargs = kwargs
+        return fake_popen
+
+    monkeypatch.setattr("ncp_langgraph.subprocess_runner._resolve_binary", fake_resolve_binary)
+    monkeypatch.setattr("subprocess.Popen", fake_factory)
+    return fake_popen
+
+
+# ── happy path ────────────────────────────────────────────────────────
+
+
+def test_returns_runner_result_with_success_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakePopen(_frames())
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    result = call_ncp_graph(
+        graph="graph.yaml",
+        brick_dir="bricks/",
+        arguments={"input": "hi"},
+    )
+
+    assert isinstance(result, ncp_langgraph.RunnerResult)
+    assert result.output_json == {"echoed": "ok"}
+    assert result.trace["result_type"] == "Success"
+    assert result.trace["trace_id"] == "trace-uuid"
+    assert result.trace["trace_path"] is None
+    assert result.structured_content["result_type"] == "Success"
+    # Success-path shutdown sentinel: the runner closed stdin and the
+    # subprocess exited cleanly. The error paths assert this; the
+    # happy path should too, so the regression-sentinel contract is
+    # locked end-to-end.
+    assert fake._exited
+    assert fake.stdin is not None
+    assert fake.stdin.closed
+
+
+def test_explicit_tool_name_overrides_auto_derive(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakePopen(_frames())
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    call_ncp_graph(
+        graph="g.yaml",
+        brick_dir="b/",
+        arguments={},
+        tool_name=DEFAULT_TOOL_NAME,
+    )
+
+    assert fake.stdin is not None
+    tools_call_frame = json.loads(fake.stdin.writes[-1])
+    assert tools_call_frame["params"]["name"] == DEFAULT_TOOL_NAME
+
+
+def test_explicit_tool_name_disambiguates_multiple_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reason `tool_name` exists: disambiguate when tools/list
+    returns multiple tools. A single-tool fake list with the same name
+    passed in does NOT prove this contract; this test does.
+    """
+    fake = _FakePopen(
+        _frames(
+            tools_list=_make_tools_list_response(
+                tools=[{"name": "a"}, {"name": "b"}],
+            ),
+        ),
+    )
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    call_ncp_graph(
+        graph="g.yaml",
+        brick_dir="b/",
+        arguments={},
+        tool_name="b",
+    )
+
+    assert fake.stdin is not None
+    tools_call_frame = json.loads(fake.stdin.writes[-1])
+    assert tools_call_frame["params"]["name"] == "b"
+
+
+def test_trace_path_string_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    call = _make_call_response(_success_result(trace_path="/tmp/abc.jsonl"))
+    fake = _FakePopen(_frames(call=call))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    result = call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+
+    assert result.trace["trace_path"] == "/tmp/abc.jsonl"
+
+
+# ── MCP frame sequence + Popen invocation ────────────────────────────
+
+
+def test_dialog_writes_four_frames_in_correct_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Locked 4-frame sequence: initialize, notifications/initialized,
+    tools/list, tools/call. Without this test the implementation could
+    silently skip ``notifications/initialized`` and most other unit
+    tests would still pass.
+    """
+    fake = _FakePopen(_frames())
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={"x": 1})
+
+    assert fake.stdin is not None
+    writes = fake.stdin.writes
+    assert len(writes) == 4
+
+    frames = [json.loads(w) for w in writes]
+
+    # Frame 1: initialize
+    assert frames[0]["method"] == "initialize"
+    assert frames[0]["id"] == 1
+    assert frames[0]["params"]["protocolVersion"] == "2025-11-25"
+    assert frames[0]["params"]["clientInfo"]["name"] == "ncp-langgraph"
+    # Lock-in: clientInfo.version must be sourced from _version.__version__
+    # (the private module that exists to break the circular import risk).
+    # Without this assertion, refactoring could silently break the MCP
+    # protocol version field.
+    assert frames[0]["params"]["clientInfo"]["version"] == ncp_langgraph.__version__
+
+    # Frame 2: notifications/initialized (no id)
+    assert frames[1]["method"] == "notifications/initialized"
+    assert "id" not in frames[1]
+
+    # Frame 3: tools/list
+    assert frames[2]["method"] == "tools/list"
+    assert frames[2]["id"] == 2
+
+    # Frame 4: tools/call
+    assert frames[3]["method"] == "tools/call"
+    assert frames[3]["id"] == 3
+    assert frames[3]["params"]["name"] == DEFAULT_TOOL_NAME
+    assert frames[3]["params"]["arguments"] == {"x": 1}
+
+
+def test_subprocess_spawned_with_utf8_and_pipe_discipline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """UTF-8 encoding is pinned; stdin/stdout are subprocess.PIPE;
+    stderr is NOT subprocess.PIPE (the file-backed-stderr deadlock
+    prevention is a locked design invariant).
+    """
+    fake = _FakePopen(_frames())
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+
+    assert fake.popen_kwargs.get("encoding") == "utf-8"
+    assert fake.popen_kwargs.get("text") is True
+    assert fake.popen_kwargs.get("stdin") is subprocess.PIPE
+    assert fake.popen_kwargs.get("stdout") is subprocess.PIPE
+    assert fake.popen_kwargs.get("stderr") is not subprocess.PIPE
+
+
+# ── argv / arguments forwarding ──────────────────────────────────────
+
+
+def test_trace_dir_set_forwards_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakePopen(_frames())
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    call_ncp_graph(
+        graph="g.yaml",
+        brick_dir="b/",
+        arguments={},
+        trace_dir="/tmp/traces",
+    )
+
+    assert fake.argv is not None
+    assert "--trace-dir" in fake.argv
+    idx = fake.argv.index("--trace-dir")
+    assert fake.argv[idx + 1] == "/tmp/traces"
+
+
+def test_trace_dir_none_omits_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakePopen(_frames())
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={}, trace_dir=None)
+
+    assert fake.argv is not None
+    assert "--trace-dir" not in fake.argv
+
+
+def test_graph_and_brick_dir_passed_to_argv(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakePopen(_frames())
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    call_ncp_graph(graph="my-graph.yaml", brick_dir="my-bricks/", arguments={})
+
+    assert fake.argv is not None
+    assert "--graph" in fake.argv
+    g_idx = fake.argv.index("--graph")
+    assert fake.argv[g_idx + 1] == "my-graph.yaml"
+    assert "--brick-dir" in fake.argv
+    b_idx = fake.argv.index("--brick-dir")
+    assert fake.argv[b_idx + 1] == "my-bricks/"
+
+
+def test_arguments_passed_to_tools_call_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakePopen(_frames())
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    call_ncp_graph(
+        graph="g.yaml",
+        brick_dir="b/",
+        arguments={"x": 1, "nested": {"y": "z"}},
+    )
+
+    assert fake.stdin is not None
+    tools_call_frame = json.loads(fake.stdin.writes[-1])
+    assert tools_call_frame["params"]["arguments"] == {"x": 1, "nested": {"y": "z"}}
+
+
+# ── input precondition errors ────────────────────────────────────────
+
+
+def test_non_dict_arguments_raise_subprocess_error_before_spawn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    popen_called = False
+
+    def fail_popen(*_args: Any, **_kwargs: Any) -> Any:
+        nonlocal popen_called
+        popen_called = True
+        raise AssertionError("subprocess.Popen must not be called")
+
+    monkeypatch.setattr("subprocess.Popen", fail_popen)
+
+    for bad in ([1, 2], "string", None, 42):
+        with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+            call_ncp_graph(
+                graph="g.yaml",
+                brick_dir="b/",
+                arguments=bad,  # type: ignore[arg-type]
+            )
+        assert "must be a dict/object" in str(exc_info.value)
+    assert popen_called is False
+
+
+def test_nan_in_arguments_raises_subprocess_error_with_clean_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_popen(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("subprocess.Popen must not be called")
+
+    monkeypatch.setattr("subprocess.Popen", fail_popen)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(
+            graph="g.yaml",
+            brick_dir="b/",
+            arguments={"x": float("nan")},
+        )
+    assert "failed to serialize" in str(exc_info.value).lower()
+
+
+# ── tools/list errors (run regression sentinel before raising) ───────
+
+
+def test_multi_tool_no_name_raises_ambiguous_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakePopen(
+        _frames(
+            tools_list=_make_tools_list_response(tools=[{"name": "a"}, {"name": "b"}]),
+        ),
+    )
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPAmbiguousToolError):
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+
+    assert fake._exited
+    assert fake.stdin is not None
+    assert fake.stdin.closed
+
+
+def test_zero_tools_raises_subprocess_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakePopen(_frames(tools_list=_make_tools_list_response(tools=[])))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "zero tools" in str(exc_info.value)
+    assert fake._exited
+    assert fake.stdin is not None
+    assert fake.stdin.closed
+
+
+def test_tool_name_not_in_list_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakePopen(_frames())
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(
+            graph="g.yaml",
+            brick_dir="b/",
+            arguments={},
+            tool_name="not-in-list",
+        )
+    assert "not in tools/list" in str(exc_info.value)
+    assert fake._exited
+    assert fake.stdin is not None
+    assert fake.stdin.closed
+
+
+def test_non_object_tool_entry_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakePopen(_frames(tools_list=_make_tools_list_response(tools=["not-a-dict"])))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "non-object tool entry" in str(exc_info.value)
+    assert fake._exited
+    assert fake.stdin is not None
+    assert fake.stdin.closed
+
+
+def test_non_string_tool_name_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakePopen(_frames(tools_list=_make_tools_list_response(tools=[{"name": 42}])))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "non-string name" in str(exc_info.value)
+    assert fake._exited
+    assert fake.stdin is not None
+    assert fake.stdin.closed
+
+
+# ── tools/call result shape validation ───────────────────────────────
+
+
+def test_missing_is_error_raises_subprocess_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    bad_result = {
+        "structuredContent": _success_result()["structuredContent"],
+        "content": [],
+    }
+    fake = _FakePopen(_frames(call=_make_call_response(bad_result)))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "isError" in str(exc_info.value)
+
+
+def test_missing_structured_content_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bad_result = {"isError": False, "content": []}
+    fake = _FakePopen(_frames(call=_make_call_response(bad_result)))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "structuredContent" in str(exc_info.value)
+
+
+def test_non_dict_structured_content_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bad_result = {"isError": False, "structuredContent": "not a dict", "content": []}
+    fake = _FakePopen(_frames(call=_make_call_response(bad_result)))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "structuredContent" in str(exc_info.value)
+
+
+def test_missing_output_json_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sc = {
+        "result_type": "Success",
+        "trace_id": "id",
+        "trace_path": None,
+        "terminal_results": [],
+    }
+    bad_result = {"isError": False, "structuredContent": sc, "content": []}
+    fake = _FakePopen(_frames(call=_make_call_response(bad_result)))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "output_json" in str(exc_info.value)
+
+
+def test_output_json_none_accepted_when_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Failure-only case carries output_json: null (valid per §5)."""
+    fake = _FakePopen(
+        _frames(call=_make_call_response(_failure_result(output_json=None))),
+    )
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPInvocationError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert exc_info.value.result_type == "Failure"
+    assert exc_info.value.structured_content["output_json"] is None
+
+
+def test_missing_trace_id_raises_subprocess_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    sc = {
+        "result_type": "Success",
+        "output_json": {},
+        "trace_path": None,
+        "terminal_results": [],
+    }
+    bad_result = {"isError": False, "structuredContent": sc, "content": []}
+    fake = _FakePopen(_frames(call=_make_call_response(bad_result)))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "trace_id" in str(exc_info.value)
+
+
+def test_invalid_trace_id_type_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bad = _success_result()
+    bad["structuredContent"]["trace_id"] = 123  # not str
+    fake = _FakePopen(_frames(call=_make_call_response(bad)))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "trace_id" in str(exc_info.value)
+
+
+def test_invalid_trace_path_type_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """trace_path must be str or None; an int is rejected."""
+    bad = _success_result()
+    bad["structuredContent"]["trace_path"] = 123
+    fake = _FakePopen(_frames(call=_make_call_response(bad)))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "trace_path" in str(exc_info.value)
+
+
+def test_missing_terminal_results_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sc = {
+        "result_type": "Success",
+        "output_json": {},
+        "trace_id": "id",
+        "trace_path": None,
+        # No terminal_results
+    }
+    bad_result = {"isError": False, "structuredContent": sc, "content": []}
+    fake = _FakePopen(_frames(call=_make_call_response(bad_result)))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "terminal_results" in str(exc_info.value)
+
+
+def test_terminal_results_must_be_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    sc = {
+        "result_type": "Success",
+        "output_json": {},
+        "trace_id": "id",
+        "trace_path": None,
+        "terminal_results": {"not": "a list"},
+    }
+    bad_result = {"isError": False, "structuredContent": sc, "content": []}
+    fake = _FakePopen(_frames(call=_make_call_response(bad_result)))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "terminal_results" in str(exc_info.value)
+
+
+def test_unknown_result_type_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bad = _success_result()
+    bad["structuredContent"]["result_type"] = "Bogus"
+    fake = _FakePopen(_frames(call=_make_call_response(bad)))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "not one of" in str(exc_info.value)
+
+
+def test_is_error_true_with_success_result_type_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Server bug: isError=true should never be paired with Success."""
+    sc = _success_result()["structuredContent"]
+    bad_result = {"isError": True, "structuredContent": sc, "content": []}
+    fake = _FakePopen(_frames(call=_make_call_response(bad_result)))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "isError=true" in str(exc_info.value)
+    assert "Success" in str(exc_info.value)
+
+
+def test_is_error_false_with_failure_or_lowconfidence_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Server bug: isError=false should never be paired with non-Success."""
+    for bad_type in ("Failure", "LowConfidence"):
+        sc = {
+            "result_type": bad_type,
+            "output_json": None,
+            "trace_id": "id",
+            "trace_path": None,
+            "terminal_results": [],
+        }
+        bad_result = {"isError": False, "structuredContent": sc, "content": []}
+        fake = _FakePopen(_frames(call=_make_call_response(bad_result)))
+        _patch_popen_and_binary(monkeypatch, fake)
+
+        with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+            call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+        assert "isError=false" in str(exc_info.value)
+
+
+# ── invocation outcomes (isError=true) ───────────────────────────────
+
+
+def test_is_error_true_failure_raises_invocation_error_with_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakePopen(
+        _frames(
+            call=_make_call_response(
+                _failure_result(
+                    result_type="Failure",
+                    trace_id="tid-abc",
+                    trace_path="/tmp/tid-abc.jsonl",
+                ),
+            ),
+        ),
+    )
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPInvocationError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    exc = exc_info.value
+    assert exc.result_type == "Failure"
+    assert exc.trace_id == "tid-abc"
+    assert exc.trace_path == "/tmp/tid-abc.jsonl"
+    assert isinstance(exc.structured_content, dict)
+
+
+def test_is_error_true_lowconfidence_raises_invocation_error_with_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakePopen(
+        _frames(
+            call=_make_call_response(
+                _failure_result(result_type="LowConfidence", trace_id="tid-xyz"),
+            ),
+        ),
+    )
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPInvocationError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert exc_info.value.result_type == "LowConfidence"
+    assert exc_info.value.trace_id == "tid-xyz"
+
+
+# ── JSON-RPC / envelope errors ───────────────────────────────────────
+
+
+def test_jsonrpc_error_response_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    init_with_error = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {"code": -32601, "message": "Method not found"},
+    }
+    fake = _FakePopen([json.dumps(init_with_error) + "\n"])
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "JSON-RPC error" in str(exc_info.value)
+
+
+def test_invalid_json_response_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakePopen(["this is not json\n"])
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "not valid JSON" in str(exc_info.value)
+
+
+def test_id_mismatch_raises_subprocess_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    bad_init = {"jsonrpc": "2.0", "id": 99, "result": {}}
+    fake = _FakePopen([json.dumps(bad_init) + "\n"])
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "id mismatch" in str(exc_info.value)
+
+
+def test_eof_before_response_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stdout returns '' before any expected response; timer did not
+    fire -> NCPSubprocessError ('subprocess closed stdout before
+    sending ... response').
+    """
+    fake = _FakePopen([])
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "closed stdout" in str(exc_info.value)
+
+
+class _RaisingReadlineStdout:
+    """Test double whose readline() always raises UnicodeDecodeError.
+
+    The runner has a dedicated `except UnicodeDecodeError` clause
+    ahead of the generic OSError handler in `_read_response`. This
+    fake exercises that code path -- which can fire in practice if
+    the subprocess emits non-UTF-8 bytes despite our `encoding="utf-8"`
+    pin (rare, but defensive).
+    """
+
+    def readline(self) -> str:
+        raise UnicodeDecodeError("utf-8", b"\xff\xff\xff", 0, 1, "invalid start byte")
+
+
+def test_unicode_decode_error_in_response_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stdout.readline() raises UnicodeDecodeError -> NCPSubprocessError
+    with a 'failed decoding ... as UTF-8' message.
+    """
+    fake = _FakePopen(_frames())
+    fake.stdout = _RaisingReadlineStdout()  # type: ignore[assignment]
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "failed decoding" in str(exc_info.value)
+    assert "UTF-8" in str(exc_info.value)
+
+
+# ── subprocess lifecycle ─────────────────────────────────────────────
+
+
+def test_non_zero_exit_after_dialog_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakePopen(_frames(), returncode=2)
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "exited non-zero" in str(exc_info.value)
+
+
+def test_graceful_shutdown_stall_without_timer_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """proc.wait() raises TimeoutExpired during graceful shutdown but
+    the global timer never fired -> NCPSubprocessError, NOT
+    NCPTimeoutError. Protects the locked distinction in
+    _close_stdin_and_assert_clean_exit.
+    """
+    fake = _FakePopen(_frames(), wait_timeout_first=True)
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "graceful shutdown stalled" in str(exc_info.value)
+
+
+# ── timer-based timeouts ─────────────────────────────────────────────
+
+
+def test_timer_fires_during_dialog_raises_timeout_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The global timer fires immediately on start() (before any read
+    succeeds). The runner's read sees an empty stdout AND
+    timeout_state['fired'] == True -> NCPTimeoutError.
+    """
+    fake = _FakePopen([])
+    _patch_popen_and_binary(monkeypatch, fake)
+    monkeypatch.setattr("threading.Timer", _ImmediateTimer)
+
+    with pytest.raises(ncp_langgraph.NCPTimeoutError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "killed by timer" in str(exc_info.value)
+    assert fake.kill_called
+
+
+def test_timer_fires_during_graceful_shutdown_raises_timeout_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dialog completes successfully, then during graceful shutdown
+    wait() raises TimeoutExpired AND timeout_state['fired'] becomes
+    True (timer fired mid-wait) -> NCPTimeoutError, NOT
+    NCPSubprocessError.
+    """
+    _CapturingTimer.last_callback = None
+    monkeypatch.setattr("threading.Timer", _CapturingTimer)
+
+    def trigger_timer() -> None:
+        if _CapturingTimer.last_callback is not None:
+            _CapturingTimer.last_callback()
+
+    fake = _FakePopen(_frames(), wait_timeout_first=True, wait_side_effect=trigger_timer)
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPTimeoutError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+    assert "killed by timer" in str(exc_info.value)
+    assert fake.kill_called
+
+
+# ── binary resolution ────────────────────────────────────────────────
+
+
+def test_explicit_path_to_directory_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(
+            graph="g.yaml",
+            brick_dir="b/",
+            arguments={},
+            binary=str(tmp_path),
+        )
+    assert "not an executable file" in str(exc_info.value)
+
+
+def test_missing_bare_name_binary_raises_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ncp_langgraph.subprocess_runner.shutil.which",
+        lambda _name: None,
+    )
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(
+            graph="g.yaml",
+            brick_dir="b/",
+            arguments={},
+            binary="definitely-not-on-path-12345",
+        )
+    assert "not found on PATH" in str(exc_info.value)
+
+
+# ── stderr-log lifecycle ─────────────────────────────────────────────
+
+
+def _collect_stderr_log_paths(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """Capture every stderr log path the runner creates."""
+    paths: list[Path] = []
+    original = __import__("tempfile").NamedTemporaryFile
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        handle = original(*args, **kwargs)
+        paths.append(Path(handle.name))
+        return handle
+
+    monkeypatch.setattr("tempfile.NamedTemporaryFile", wrapper)
+    return paths
+
+
+def test_stderr_log_deleted_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    paths = _collect_stderr_log_paths(monkeypatch)
+    fake = _FakePopen(_frames())
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+
+    assert len(paths) == 1
+    assert not paths[0].exists()
+
+
+def test_stderr_log_deleted_on_invocation_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    paths = _collect_stderr_log_paths(monkeypatch)
+    fake = _FakePopen(_frames(call=_make_call_response(_failure_result())))
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPInvocationError):
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+
+    assert len(paths) == 1
+    assert not paths[0].exists()
+
+
+def test_stderr_log_deleted_on_ambiguous_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _collect_stderr_log_paths(monkeypatch)
+    fake = _FakePopen(
+        _frames(
+            tools_list=_make_tools_list_response(tools=[{"name": "a"}, {"name": "b"}]),
+        ),
+    )
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPAmbiguousToolError):
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+
+    assert len(paths) == 1
+    assert not paths[0].exists()
+
+
+def test_empty_stderr_log_deleted_on_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty stderr logs are deleted regardless of exception type (the
+    empty-log override in `_cleanup_stderr_log`). This test pins that
+    behavior: subprocess returns non-zero exit, no stderr written, log
+    is deleted.
+    """
+    paths = _collect_stderr_log_paths(monkeypatch)
+    fake = _FakePopen(_frames(), returncode=2)
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError):
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+
+    assert len(paths) == 1
+    assert not paths[0].exists()
+
+
+def test_stderr_log_kept_on_subprocess_error_with_nonempty_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-empty stderr log is preserved on NCPSubprocessError so its
+    tail is available for diagnostics.
+    """
+    paths = _collect_stderr_log_paths(monkeypatch)
+    fake = _FakePopen(_frames(), returncode=2)
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    original_factory = subprocess.Popen  # type: ignore[misc]
+
+    def writing_factory(*args: Any, **kwargs: Any) -> Any:
+        proc = original_factory(*args, **kwargs)  # type: ignore[operator]
+        stderr_handle = kwargs.get("stderr")
+        if hasattr(stderr_handle, "write"):
+            stderr_handle.write(b"panic: something went wrong\n")
+            stderr_handle.flush()
+        return proc
+
+    monkeypatch.setattr("subprocess.Popen", writing_factory)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+
+    # Stderr tail must appear in the exception message -- preserving
+    # the file on disk is only half the diagnostic plumbing; the user
+    # sees the tail through the exception.
+    assert "panic: something went wrong" in str(exc_info.value)
+    assert len(paths) == 1
+    assert paths[0].exists()
+    paths[0].unlink()
+
+
+def test_stderr_log_kept_on_timeout_error_with_nonempty_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-empty stderr log is preserved on NCPTimeoutError so its
+    tail is available for diagnostics. Mirrors the subprocess-error
+    case but the exception is NCPTimeoutError.
+    """
+    paths = _collect_stderr_log_paths(monkeypatch)
+
+    _CapturingTimer.last_callback = None
+    monkeypatch.setattr("threading.Timer", _CapturingTimer)
+
+    def trigger_timer() -> None:
+        if _CapturingTimer.last_callback is not None:
+            _CapturingTimer.last_callback()
+
+    fake = _FakePopen(_frames(), wait_timeout_first=True, wait_side_effect=trigger_timer)
+    _patch_popen_and_binary(monkeypatch, fake)
+
+    original_factory = subprocess.Popen  # type: ignore[misc]
+
+    def writing_factory(*args: Any, **kwargs: Any) -> Any:
+        proc = original_factory(*args, **kwargs)  # type: ignore[operator]
+        stderr_handle = kwargs.get("stderr")
+        if hasattr(stderr_handle, "write"):
+            stderr_handle.write(b"timeout panic\n")
+            stderr_handle.flush()
+        return proc
+
+    monkeypatch.setattr("subprocess.Popen", writing_factory)
+
+    with pytest.raises(ncp_langgraph.NCPTimeoutError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+
+    assert "timeout panic" in str(exc_info.value)
+    assert len(paths) == 1
+    assert paths[0].exists()
+    paths[0].unlink()
+
+
+def test_popen_oserror_raises_subprocess_error_and_deletes_empty_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Spawn-failure path: subprocess.Popen raises OSError. The runner
+    wraps it as NCPSubprocessError with a 'failed to spawn' message,
+    and the empty stderr log is deleted (empty-log override applies
+    even on kept-by-exception-type).
+    """
+    paths = _collect_stderr_log_paths(monkeypatch)
+
+    def fail_popen(*_args: Any, **_kwargs: Any) -> Any:
+        raise OSError("boom")
+
+    monkeypatch.setattr(
+        "ncp_langgraph.subprocess_runner._resolve_binary",
+        lambda _b: Path("/fake/bin"),
+    )
+    monkeypatch.setattr("subprocess.Popen", fail_popen)
+
+    with pytest.raises(ncp_langgraph.NCPSubprocessError) as exc_info:
+        call_ncp_graph(graph="g.yaml", brick_dir="b/", arguments={})
+
+    assert "failed to spawn" in str(exc_info.value)
+    assert len(paths) == 1
+    assert not paths[0].exists()
+
+
+# ── integration tests (gated on ``mcp_server_binary`` fixture) ───────
+
+
+def test_real_echo_pipeline_returns_success(
+    mcp_server_binary: Path,
+    echo_pipeline_graph: Path,
+    brick_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """End-to-end: drive the real binary through the echo pipeline."""
+    result = call_ncp_graph(
+        graph=echo_pipeline_graph,
+        brick_dir=brick_dir,
+        arguments={"smoke": "hello"},
+        trace_dir=tmp_path,
+        binary=mcp_server_binary,
+        timeout=30.0,
+    )
+
+    assert isinstance(result, ncp_langgraph.RunnerResult)
+    assert result.trace["result_type"] == "Success"
+    assert isinstance(result.trace["trace_id"], str)
+    assert result.trace["trace_id"]
+
+
+def test_real_trace_file_written_when_trace_dir_set(
+    mcp_server_binary: Path,
+    echo_pipeline_graph: Path,
+    brick_dir: Path,
+    tmp_path: Path,
+) -> None:
+    result = call_ncp_graph(
+        graph=echo_pipeline_graph,
+        brick_dir=brick_dir,
+        arguments={"smoke": "hello"},
+        trace_dir=tmp_path,
+        binary=mcp_server_binary,
+    )
+
+    trace_path = result.trace["trace_path"]
+    assert isinstance(trace_path, str)
+    p = Path(trace_path)
+    assert p.is_file()
+    assert p.stat().st_size > 0
+    # Consistency with the other two integration tests:
+    assert result.trace["trace_id"]
+
+
+def test_real_no_trace_dir_gives_null_trace_path(
+    mcp_server_binary: Path,
+    echo_pipeline_graph: Path,
+    brick_dir: Path,
+) -> None:
+    result = call_ncp_graph(
+        graph=echo_pipeline_graph,
+        brick_dir=brick_dir,
+        arguments={"smoke": "hello"},
+        binary=mcp_server_binary,
+    )
+
+    assert result.trace["trace_path"] is None
+    assert isinstance(result.trace["trace_id"], str)
+    assert result.trace["trace_id"]


### PR DESCRIPTION
## Summary

- Replaces the `subprocess_runner.py` stub with the real implementation per `docs/LANGGRAPH_ADAPTER.md` §3.3 + §5. Each `call_ncp_graph(...)` invocation spawns a fresh `ncp-mcp-server` subprocess, drives the locked four-frame MCP dialog, asserts a clean post-dialog graceful-shutdown, and returns a `RunnerResult`.
- New private `_version.py` module: runtime source of truth for `__version__`, used by both `__init__.py` (re-export) and `subprocess_runner.py` (MCP `clientInfo.version`). Breaks the circular-import risk.
- Adds `tests/test_subprocess_runner.py`: 50 unit tests (mocked Popen) + 3 gated integration tests against the real `ncp-mcp-server` binary.
- Extends `tests/conftest.py` with `repo_root`, `echo_pipeline_graph`, `brick_dir`, `mcp_server_binary` fixtures plus a `_skip_or_fail_missing` helper that fails loudly (not silently skips) when `NCP_MCP_SERVER` is set but a fixture path is broken.

See the commit message on `a7aadef` for the full breakdown of locked runtime invariants (one subprocess per call, UTF-8 pinning, file-backed stderr, regression-sentinel graceful-shutdown gate, strict JSON, library-boundary type checks, isError/result_type cross-check, etc.).

## Test plan

- [x] `python -m mypy --strict src` — no issues in 5 source files
- [x] `python -m ruff check .` — clean
- [x] `python -m ruff format --check .` — 8 files already formatted
- [x] `python -m pytest` — 56 passed, 3 skipped (gated)
- [x] `NCP_MCP_SERVER=target/release/ncp-mcp-server.exe python -m pytest` — **59 passed** (full integration end-to-end against real binary)
- [x] `cargo build -p ncp-mcp-server --release --locked` — clean
- [ ] CI: `langgraph-test` job goes green on this PR
- [ ] CI: existing required checks (DCO, fmt, clippy, test, mcp-smoke, validate, wasm-build) all green

## Refs

- Design contract: [`docs/LANGGRAPH_ADAPTER.md`](docs/LANGGRAPH_ADAPTER.md) (PR #40)
- Skeleton: PR #41 (`python/ncp-langgraph/` v0.1.0.dev0)
- Plan: Phase 3A.3 PR C → D → E → F → G remaining