### PR TITLE
docs(langgraph): example + adopter docs (PR 3A.3-E)

### DIFF
--- a/docs/LANGGRAPH_ADAPTER.md
+++ b/docs/LANGGRAPH_ADAPTER.md
@@ -606,7 +606,33 @@ adapter tag push to confirm no runtime workflows fired.
 
 ---
 
-## 15. Out of scope (deferred)
+## 15. Examples
+
+Adopter-facing examples live in
+[`examples/langgraph/`](https://github.com/madeinplutofabio/neural-computation-protocol/tree/main/examples/langgraph).
+
+The v0.1.0 example is a lead-qualification workflow shape: a LangGraph
+`StateGraph` with one `NCPNode`. It is currently stubbed on the bundled
+`echo-pipeline` NCP graph until issue
+[#29](https://github.com/madeinplutofabio/neural-computation-protocol/issues/29)
+ships the real `examples/graphs/lead-qualification/` graph.
+
+Substitution is documented inline in the example script (`TODO(#29)`
+comment in the module docstring) and in
+[`examples/langgraph/README.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/examples/langgraph/README.md).
+
+Run end-to-end from a workspace clone:
+
+```bash
+cargo install ncp-mcp-server --version 0.1.0 --locked
+python -m pip install -e python/ncp-langgraph
+python -m pip install -r examples/langgraph/requirements.txt
+python examples/langgraph/lead_qualification_agent.py
+```
+
+Expected output: the final LangGraph state dict with `company_url`, `target_icp`, `qualification`, and `ncp_trace`.
+
+## 16. Out of scope (deferred)
 
 Tracked items that v0.1.0 explicitly does NOT ship:
 

--- a/examples/langgraph/README.md
+++ b/examples/langgraph/README.md
@@ -1,0 +1,133 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Copyright 2026 Fabio Marcello Salvadori
+-->
+
+# `examples/langgraph/` -- LangGraph adapter examples
+
+This directory shows how to drop an [NCP] graph into a
+[LangGraph] workflow using
+[`ncp-langgraph`](https://github.com/madeinplutofabio/neural-computation-protocol/tree/main/python/ncp-langgraph),
+the Python adapter that wraps `ncp-mcp-server` as a LangGraph node.
+
+**One NCP graph = one LangGraph node.**
+`NCPNode.from_subprocess(...)` returns a callable instance; register
+it via `builder.add_node(name, instance)`, compile your `StateGraph`,
+and invoke.
+
+[NCP]: https://github.com/madeinplutofabio/neural-computation-protocol
+[LangGraph]: https://github.com/langchain-ai/langgraph
+
+---
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| `README.md` | This file. |
+| `lead_qualification_agent.py` | End-to-end runnable example: LangGraph workflow shape for lead qualification, currently stubbed on the bundled `echo-pipeline` NCP graph. |
+| `requirements.txt` | Python dependencies required to run the example (LangGraph; `ncp-langgraph` is installed separately, see below). |
+
+---
+
+## Current stub: `echo-pipeline`
+
+The example **wires the bundled `echo-pipeline` NCP graph** as the
+underlying graph. Echo is a passthrough; it mirrors its input back,
+so the `qualification` output you'll see is **NOT** a real
+qualification verdict.
+
+The intended graph is `examples/graphs/lead-qualification/`, tracked as
+issue [#29](https://github.com/madeinplutofabio/neural-computation-protocol/issues/29).
+Once that graph lands, swap the `graph=` path in the example and the
+output becomes a real qualification result.
+
+This substitution decouples Phase 3A.3 (the adapter) from issue #29
+(the graph) so the adapter ships without blocking on graph-authoring
+work.
+
+---
+
+## Quick start
+
+### 1. Install the runtime
+
+```bash
+cargo install ncp-mcp-server --version 0.1.0 --locked
+```
+
+The version is pinned to keep this example reproducible against
+`ncp-langgraph v0.1.x`. That command puts `ncp-mcp-server` on `PATH`
+(via `$CARGO_HOME/bin`). It's the Rust binary that `ncp-langgraph`
+spawns as a subprocess.
+
+### 2. Install the Python adapter
+
+Until `ncp-langgraph` v0.1.0 is published to PyPI in Phase 3A.3 PR F,
+install editable from a workspace clone:
+
+```bash
+python -m pip install -e python/ncp-langgraph
+```
+
+After publish, the same package will be installable from PyPI directly:
+
+```bash
+python -m pip install ncp-langgraph
+```
+
+### 3. Install example dependencies (LangGraph)
+
+```bash
+python -m pip install -r examples/langgraph/requirements.txt
+```
+
+### 4. Run the example
+
+```bash
+python examples/langgraph/lead_qualification_agent.py
+```
+
+Expected output: the final LangGraph state dict with
+- `company_url` and `target_icp` (your initial state)
+- `qualification` (echoed input, the stub behavior)
+- `ncp_trace` (`result_type`, `trace_id`, `trace_path`)
+
+---
+
+## How the example works
+
+```python
+qualify_lead = NCPNode.from_subprocess(
+    graph="examples/graphs/echo-pipeline/graph.yaml",  # TODO(#29)
+    brick_dir="examples/bricks",
+    output_key="qualification",
+    timeout=30.0,
+)
+
+builder = StateGraph(LeadState)
+builder.add_node("qualify_lead", qualify_lead)
+builder.add_edge(START, "qualify_lead")
+builder.add_edge("qualify_lead", END)
+compiled = builder.compile()
+
+result = compiled.invoke({
+    "company_url": "https://example.com",
+    "target_icp": "B2B SaaS selling to creators",
+})
+# result["qualification"]  -- the NCP graph's output_json
+# result["ncp_trace"]      -- {"result_type", "trace_id", "trace_path"}
+```
+
+`NCPNode.__call__` does NOT mutate `state`; it returns a NEW partial
+state update which LangGraph merges according to your `StateGraph`'s
+schema + reducers.
+
+---
+
+## Full design reference
+
+[`docs/LANGGRAPH_ADAPTER.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/LANGGRAPH_ADAPTER.md)
+is the binding design contract for `ncp-langgraph`, including the
+locked `NCPNode` signature, state input/output semantics, exception
+model, and v0.1.0 limitations.

--- a/examples/langgraph/lead_qualification_agent.py
+++ b/examples/langgraph/lead_qualification_agent.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+
+"""LangGraph lead-qualification example using ncp-langgraph.
+
+This example demonstrates the canonical adopter integration pattern:
+
+1. Build a LangGraph ``StateGraph`` for your workflow shape.
+2. Wrap an NCP graph as an ``NCPNode`` via
+   :meth:`NCPNode.from_subprocess`.
+3. Register the ``NCPNode`` in the ``StateGraph`` via
+   ``builder.add_node(name, instance)``.
+4. Compile + invoke.
+
+UNDERLYING NCP GRAPH (current stub vs intended)
+================================================
+This example WIRES the echo-pipeline graph (a passthrough NCP graph
+bundled with the workspace) as the underlying NCP graph. Echo just
+mirrors its input back, so the ``qualification`` output you'll see is
+NOT a real qualification verdict -- it's the state you sent in.
+
+# TODO(#29): Replace echo-pipeline with the lead-qualification graph
+# once examples/graphs/lead-qualification/ lands.
+
+Tracking the real lead-qualification graph: issue #29
+(https://github.com/madeinplutofabio/neural-computation-protocol/issues/29).
+
+This substitution decouples Phase 3A.3 (the adapter) from issue #29
+(the graph) so the adapter can ship without blocking on graph-authoring
+work.
+
+REQUIREMENTS
+============
+- Run from a clone of the NCP workspace. The example resolves the
+  echo-pipeline graph + bricks via relative paths from this file.
+- ``cargo install ncp-mcp-server --version 0.1.0 --locked`` (or build
+  from source).
+- ``pip install -e python/ncp-langgraph`` (or
+  ``pip install ncp-langgraph`` once published to PyPI in PR F).
+- See ``examples/langgraph/requirements.txt`` for the Python deps.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, TypedDict
+
+from langgraph.graph import END, START, StateGraph
+from ncp_langgraph import NCPNode
+
+# ── workspace paths ──────────────────────────────────────────────────
+
+
+_WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+_ECHO_GRAPH = _WORKSPACE_ROOT / "examples" / "graphs" / "echo-pipeline" / "graph.yaml"
+_BRICK_DIR = _WORKSPACE_ROOT / "examples" / "bricks"
+
+
+# ── LangGraph state schema ───────────────────────────────────────────
+
+
+class LeadState(TypedDict, total=False):
+    """State carried across the LangGraph workflow.
+
+    ``qualification`` and ``ncp_trace`` are populated by the NCPNode's
+    partial state update (LangGraph merges them in via the default
+    last-write-wins reducer).
+    """
+
+    company_url: str
+    target_icp: str
+    qualification: dict[str, Any]
+    ncp_trace: dict[str, Any]
+
+
+# ── build the workflow ───────────────────────────────────────────────
+
+
+def build_lead_qualifier() -> Any:
+    """Build and compile the LangGraph workflow.
+
+    Returns the compiled graph (a Runnable) ready to ``.invoke(state)``.
+    """
+    qualify_lead = NCPNode.from_subprocess(
+        graph=_ECHO_GRAPH,
+        brick_dir=_BRICK_DIR,
+        # Surface the NCP graph's output under a domain-meaningful
+        # key. Echo just mirrors input, so while we're stubbed on
+        # echo-pipeline this looks like state echo; once the real
+        # lead-qualification graph lands (#29) it'll carry icp_match,
+        # score, reasons, etc.
+        output_key="qualification",
+        timeout=30.0,
+    )
+
+    builder: StateGraph = StateGraph(LeadState)
+    builder.add_node("qualify_lead", qualify_lead)
+    builder.add_edge(START, "qualify_lead")
+    builder.add_edge("qualify_lead", END)
+    return builder.compile()
+
+
+# ── run end-to-end ───────────────────────────────────────────────────
+
+
+def main() -> None:
+    # Sanity-check workspace assets before invoking. Gives a clear
+    # error rather than a confusing NCP subprocess failure when the
+    # user runs the example outside a workspace clone.
+    if not _ECHO_GRAPH.is_file():
+        sys.exit(
+            f"Example asset missing: {_ECHO_GRAPH}\n"
+            f"Run this example from a clone of the NCP workspace; the "
+            f"echo-pipeline graph and bricks are bundled at "
+            f"examples/graphs/echo-pipeline/ and examples/bricks/."
+        )
+    if not _BRICK_DIR.is_dir():
+        sys.exit(
+            f"Example asset missing: {_BRICK_DIR}\n"
+            f"Run this example from a clone of the NCP workspace; the "
+            f"echo-pipeline graph and bricks are bundled at "
+            f"examples/graphs/echo-pipeline/ and examples/bricks/."
+        )
+
+    workflow = build_lead_qualifier()
+
+    initial_state: LeadState = {
+        "company_url": "https://example.com",
+        "target_icp": "B2B SaaS selling to creators",
+    }
+
+    print("=== Invoking lead-qualification workflow ===")
+    print(f"Initial state: {dict(initial_state)}")
+    print()
+
+    final_state = workflow.invoke(initial_state)
+
+    print("=== Final state ===")
+    for key, value in final_state.items():
+        print(f"  {key}: {value}")
+    print()
+
+    # While stubbed on echo-pipeline, qualification mirrors the input
+    # state. When the real graph lands (#29) it carries the actual
+    # qualification verdict.
+    print("=== NOTE ===")
+    print(
+        "qualification above mirrors the input state because this "
+        "example is currently stubbed on the echo-pipeline graph. "
+        "See module docstring TODO(#29) for the planned replacement."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph/requirements.txt
+++ b/examples/langgraph/requirements.txt
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+#
+# Python dependencies for examples/langgraph/lead_qualification_agent.py.
+#
+# Note: ncp-langgraph is intentionally NOT listed here. It must be
+# installed separately because Phase 3A.3 PR E lands before PyPI
+# publish (PR F), and the editable workspace install is `0.1.0.dev0`
+# which would not satisfy a `>=0.1.0` pin. Install it explicitly:
+#
+#   # Pre-publish (from workspace clone):
+#   python -m pip install -e python/ncp-langgraph
+#
+#   # Post-publish:
+#   python -m pip install ncp-langgraph
+#
+# Also note: `cargo install ncp-mcp-server --version 0.1.0 --locked`
+# is a separate prerequisite (the Rust binary that ncp-langgraph
+# spawns); it is not a pip dependency. The version is pinned so the
+# example stays reproducible against ncp-langgraph v0.1.x.
+
+langgraph>=1.0.0,<2.0.0

--- a/python/ncp-langgraph/README.md
+++ b/python/ncp-langgraph/README.md
@@ -5,67 +5,114 @@
 
 # ncp-langgraph
 
-> **Pre-release placeholder.** `ncp-langgraph v0.1.0.dev0` is the
-> skeleton package for the upcoming v0.1.0 release. The public API
-> surface is stubbed but not yet implemented; the executable API paths
-> (`NCPNode.from_subprocess(...)`, `NCPNode.__call__(...)`, and
-> `call_ncp_graph(...)`) raise `NotImplementedError`. Track progress
-> on the
-> [Phase 3A.3 milestone](https://github.com/madeinplutofabio/neural-computation-protocol/issues?q=is%3Aissue+label%3Aphase-3.A.3).
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
 
-LangGraph adapter for the
-[Neural Computation Protocol (NCP)](https://github.com/madeinplutofabio/neural-computation-protocol).
+LangGraph adapter for the [Neural Computation Protocol (NCP)](https://github.com/madeinplutofabio/neural-computation-protocol).
 
-`ncp-langgraph` will let a LangGraph `StateGraph` invoke an NCP graph
-as a node by spawning the
-[`ncp-mcp-server`](https://crates.io/crates/ncp-mcp-server) binary and
-talking to it over stdio. One NCP graph = one LangGraph node. No glue
-code, no protocol-buffer plumbing, no PyO3 (in v0.1.0).
+`ncp-langgraph` lets you wrap any NCP graph as a LangGraph node:
+`NCPNode.from_subprocess(...)` returns a callable instance that spawns
+`ncp-mcp-server` over stdio, performs the locked MCP dialog, and
+returns a partial state-update dict ready for LangGraph to merge.
 
-## Status
+**One NCP graph = one LangGraph node.** No glue code, no
+protocol-buffer plumbing, no PyO3 (in v0.1.0).
 
-- **v0.1.0.dev0** (this release): package skeleton + build/lint/test
-  scaffolding. No runnable API.
-- **v0.1.0** (next release): `NCPNode.from_subprocess(...)` and
-  `call_ncp_graph(...)` shipped against the locked design contract
-  in
-  [`docs/LANGGRAPH_ADAPTER.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/LANGGRAPH_ADAPTER.md).
+## Quick start
 
-## Scope (v0.1.0)
+```python
+from typing import Any, TypedDict
 
-- **Invocation strategy:** subprocess via `ncp-mcp-server` over stdio
-  JSON-RPC. No HTTP transport, no PyO3 binding in v0.
-- **Sync only.** `NCPAsyncNode` is a v0.2.0+ addition.
-- **One subprocess per call.** No persistent pool in v0.1.0 (deferred).
-- **One graph per `NCPNode` instance.** Multi-graph adapter instances
-  are a v0.2.0+ addition.
+from langgraph.graph import END, START, StateGraph
 
-For the full design contract, locked signature, state semantics, and
-exception model, see
-[`docs/LANGGRAPH_ADAPTER.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/LANGGRAPH_ADAPTER.md).
+from ncp_langgraph import NCPNode
+
+
+class State(TypedDict, total=False):
+    company_url: str
+    qualification: dict[str, Any]
+    ncp_trace: dict[str, Any]
+
+
+qualify_lead = NCPNode.from_subprocess(
+    graph="/abs/path/to/lead-qualification.yaml",
+    brick_dir="/abs/path/to/bricks",
+    output_key="qualification",
+    timeout=30.0,
+)
+
+builder = StateGraph(State)
+builder.add_node("qualify_lead", qualify_lead)
+builder.add_edge(START, "qualify_lead")
+builder.add_edge("qualify_lead", END)
+compiled = builder.compile()
+
+result = compiled.invoke({"company_url": "https://example.com"})
+
+# result["qualification"]  -- the NCP graph's output_json
+# result["ncp_trace"]      -- {"result_type", "trace_id", "trace_path"}
+```
+
+For a runnable end-to-end example using the bundled echo-pipeline
+graph (stub until [issue #29](https://github.com/madeinplutofabio/neural-computation-protocol/issues/29)
+ships the real lead-qualification graph), see
+[`examples/langgraph/`](https://github.com/madeinplutofabio/neural-computation-protocol/tree/main/examples/langgraph).
 
 ## Install
 
-```bash
-pip install ncp-langgraph
-```
-
-`ncp-langgraph` requires the `ncp-mcp-server` binary at runtime. Install
-it separately from crates.io:
+### 1. The NCP MCP adapter binary
 
 ```bash
-cargo install ncp-mcp-server --locked
+cargo install ncp-mcp-server --version 0.1.0 --locked
 ```
 
-The Python package does not bundle the binary because pip cannot ship a
-Rust executable.
+The version is pinned to keep `ncp-langgraph v0.1.x` reproducible
+against a known `ncp-mcp-server` release.
+
+### 2. The Python adapter (this package)
+
+Until v0.1.0 is published to PyPI in Phase 3A.3 PR F, install editable
+from a workspace clone:
+
+```bash
+python -m pip install -e python/ncp-langgraph
+```
+
+After publish:
+
+```bash
+python -m pip install ncp-langgraph
+```
+
+`ncp-langgraph` does NOT bundle the `ncp-mcp-server` binary in v0.1.0.
+The binary is distributed separately as the Rust crate
+`ncp-mcp-server`; install it independently and keep it on `PATH`, or
+pass its absolute path via `NCPNode.from_subprocess(binary=...)`.
 
 ## Requirements
 
 - Python 3.10+
-- `ncp-mcp-server v0.1.x` on `PATH` or an absolute path passed via
-  `NCPNode.from_subprocess(binary=...)`
+- `ncp-mcp-server v0.1.x` on `PATH` (or pass an absolute path via
+  `NCPNode.from_subprocess(binary=...)`)
 - LangGraph 1.x
+
+## v0.1.0 scope and limitations (honest)
+
+- **Sync only.** `NCPNode` exposes a synchronous `__call__`. Native
+  async support (`NCPAsyncNode`) is a v0.2.0+ addition.
+- **One subprocess per call.** Each invocation spawns a fresh
+  `ncp-mcp-server` process. No persistent pool. Negligible cost for
+  typical agent workflows; significant for hot-loop / per-token use.
+  Persistent pool is a v0.2.0+ perf optimization.
+- **One graph per `NCPNode` instance.** Multi-graph adapter instances
+  are a v0.2.0+ addition.
+- **Subprocess invocation only.** PyO3 direct binding and Streamable
+  HTTP transport are deferred (see
+  [`docs/LANGGRAPH_ADAPTER.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/LANGGRAPH_ADAPTER.md) §11
+  and future-work issues
+  [#34](https://github.com/madeinplutofabio/neural-computation-protocol/issues/34)
+  and
+  [#36](https://github.com/madeinplutofabio/neural-computation-protocol/issues/36)).
 
 ## License
 
@@ -75,6 +122,7 @@ Apache-2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).
 
 - [NCP project](https://github.com/madeinplutofabio/neural-computation-protocol)
 - [Design doc](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/LANGGRAPH_ADAPTER.md)
+- [Examples](https://github.com/madeinplutofabio/neural-computation-protocol/tree/main/examples/langgraph)
 - [MCP adapter (`ncp-mcp-server`)](https://crates.io/crates/ncp-mcp-server)
 - [Changelog](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/python/ncp-langgraph/CHANGELOG.md)
 - [Issues](https://github.com/madeinplutofabio/neural-computation-protocol/issues)


### PR DESCRIPTION
## Summary

Ships the Phase 3A.3 PR E deliverable: a runnable LangGraph example, an adopter-facing example README, the example dependency manifest, the full quick-start in the package README, and a new Examples section in the design doc.

- **`examples/langgraph/lead_qualification_agent.py`** — runnable LangGraph `StateGraph` with one `NCPNode`, stubbed on the bundled `echo-pipeline` graph until [#29](https://github.com/madeinplutofabio/neural-computation-protocol/issues/29). `TODO(#29)` comment present verbatim per the locked plan. Verified end-to-end against a real `ncp-mcp-server` binary on Windows.
- **`examples/langgraph/README.md`** — adopter quick-start, current-stub disclosure, install discipline (pinned `cargo install ncp-mcp-server --version 0.1.0 --locked`).
- **`examples/langgraph/requirements.txt`** — intentionally does NOT pin `ncp-langgraph` because PR E lands before PyPI publish (PR F) and the editable workspace install is `0.1.0.dev0`. Documents both pre-publish and post-publish install patterns.
- **`python/ncp-langgraph/README.md`** — replaces the PR B placeholder with the locked v0.1.0 quick-start, badges row, honest scope/limitations section, and honest pre/post-publish install discipline (PR G flips to PyPI-only). Removes the "pip cannot install a Rust executable" overclaim (Python wheels CAN carry native binaries; the accurate statement is that this package doesn't bundle the Rust binary in v0.1.0).
- **`docs/LANGGRAPH_ADAPTER.md`** — new `## 15. Examples` section; old `## 15. Out of scope (deferred)` renumbered to `## 16.`. Verified no anchor refs to §15 exist anywhere in the repo before renumbering.

See commit `3967c1e` for the full breakdown of the design and verification.

## Test plan

- [x] `python -m mypy --strict src` — no issues, 5 files
- [x] `python -m ruff check .` — All checks passed
- [x] `python -m ruff format --check .` — 9 files already formatted
- [x] `python -m pytest` — 79 passed, 3 gated skipped
- [x] `NCP_MCP_SERVER=target/release/ncp-mcp-server.exe python -m pytest` — **82 passed** end-to-end
- [x] `python -m py_compile examples/langgraph/lead_qualification_agent.py` — clean
- [x] `python examples/langgraph/lead_qualification_agent.py` end-to-end against a real `ncp-mcp-server` binary: Success terminal, valid `trace_id` UUID, expected final state shape
- [ ] CI: `langgraph-test` job goes green on this PR
- [ ] CI: existing required checks (DCO, fmt, clippy, test, mcp-smoke, validate, wasm-build) all green

## Refs

- Design contract: [`docs/LANGGRAPH_ADAPTER.md`](docs/LANGGRAPH_ADAPTER.md) (PR #40)
- Skeleton: PR #41
- Subprocess runner: PR #42
- NCPNode wrapper: PR #43
- Stubbed graph tracked as issue #29
- Plan: Phase 3A.3 PR F (PyPI publish prep) + PR G (mandatory front-door doc sync) remaining