### PR TITLE
build(langgraph): bump to v0.1.0 + PyPI publish ceremony (PR 3A.3-F)

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -570,3 +570,320 @@ This publishes **`ncp-mcp-server` only**. No GitHub Release artifacts
 for the adapter in v0.1.0. If binary-archive or container distribution
 demand surfaces later, an adapter-scoped release workflow
 (triggered by `ncp-mcp-server-v*` tags) can be added then.
+
+---
+
+## Python adapter publish (`ncp-langgraph`)
+
+PyPI-first publish flow for the LangGraph adapter package. Phase 3A.3
+ships `ncp-langgraph v0.1.0` to PyPI ONLY -- **no GitHub Release, no
+GHCR image, no Zenodo archive**. The runtime publish ceremony
+(sections 1-8 above) does NOT apply. PR F prepares the version bump +
+`CHANGELOG.md` flip; the ceremony below runs out-of-band after PR F
+merges and PR G is drafted, CI-green, and review-approved.
+
+### Why a distinct flow
+
+Same tag-pattern hazard as `ncp-mcp-server`: a bare `v*` tag would
+fire `release.yml` + `docker.yml`, producing GitHub Release + Docker
+artifacts under a Python-package version label -- broken provenance,
+wasted CI. The Python-package tag pattern is crate-name-prefixed for
+the same reason.
+
+**Python-package tags MUST NOT start with `v`.** Use the
+`ncp-langgraph-v*` pattern.
+
+### Tag pattern (LOCKED)
+
+| Crate / Package | Tag pattern | Workflows that fire on push |
+|---|---|---|
+| `ncp-runtime` | `v0.3.6`, `v0.3.7-rc.1`, etc. | `release.yml` + `docker.yml` (correct -- runtime release) |
+| `ncp-mcp-server` | `ncp-mcp-server-v0.1.0`, `ncp-mcp-server-v0.1.0-rc.1`, etc. | **None** (correct -- crates.io-first) |
+| `ncp-langgraph` | `ncp-langgraph-v0.1.0`, `ncp-langgraph-v0.1.0-rc.1`, etc. | **None** (correct -- PyPI-first) |
+
+### Pre-flight gates (required from clean main)
+
+From an up-to-date `main` checkout, against the version PR F bumped to
+(`0.1.0`). **All `python -m <tool>` invocations in this section and
+in the release ceremony below assume the release venv created in the
+first block is currently active.** Do NOT deactivate between
+pre-flight gates and ceremony steps.
+
+```bash
+# Release venv: clean Python environment with the package's [dev]
+# extras installed so the python -m <tool> discipline below resolves
+# ruff, mypy, build, twine, pytest from this venv (not from whatever
+# the release machine happens to have on PATH). `build` and `twine`
+# are also listed explicitly so the ceremony stays robust if the
+# [dev] extra ever drops them.
+python -m venv /tmp/ncp-lg-release
+. /tmp/ncp-lg-release/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e "python/ncp-langgraph[dev]" build twine
+
+# Version-parity guard: runtime __version__ MUST match the installed
+# package metadata version. Directly catches pyproject.toml /
+# _version.py / test_smoke.py drift before the publish gates run.
+python - <<'PY'
+import importlib.metadata as md
+
+import ncp_langgraph
+
+assert ncp_langgraph.__version__ == "0.1.0"
+assert md.version("ncp-langgraph") == "0.1.0"
+print("runtime and package metadata versions match")
+PY
+
+# Build the MCP adapter binary that integration tests need:
+cargo build -p ncp-mcp-server --release --locked
+
+# Package gates:
+cd python/ncp-langgraph
+python -m ruff check .
+python -m ruff format --check .
+python -m mypy --strict src
+NCP_MCP_SERVER=../../target/release/ncp-mcp-server python -m pytest
+
+# Build + verify the wheel:
+rm -rf dist/
+python -m build
+
+# PEP 561 marker MUST travel inside the wheel because the package
+# advertises `Typing :: Typed`:
+python - <<'PY'
+from pathlib import Path
+import zipfile
+
+wheel = next(Path("dist").glob("*.whl"))
+with zipfile.ZipFile(wheel) as z:
+    names = set(z.namelist())
+assert "ncp_langgraph/py.typed" in names
+print("py.typed present in wheel")
+PY
+
+python -m twine check dist/*
+cd ../..
+```
+
+All must exit 0. `python -m twine check` is the PyPI-rendering analog
+of the crates.io README link audit in §3.1; it validates `README.md`
+will render correctly on the PyPI landing page and that the wheel +
+sdist metadata are well-formed.
+
+### TestPyPI distribution-filename immutability (CRITICAL)
+
+**TestPyPI is a one-shot rehearsal. PyPI and TestPyPI distribution
+filenames are immutable once uploaded.**
+
+Once `ncp-langgraph 0.1.0` is uploaded to TestPyPI under the RC
+rehearsal, **the `ncp_langgraph-0.1.0-*.whl` and
+`ncp-langgraph-0.1.0.tar.gz` filenames are permanently reserved**.
+The same applies to real PyPI. Project deletion does NOT free the
+filenames.
+
+If the TestPyPI upload succeeds but verification (ceremony step 4)
+fails, the ONLY safe path is **fix-forward with a version bump**:
+
+- Diagnose the issue and fix the bug or metadata.
+- **Open a follow-up version-fix PR** that updates `pyproject.toml`,
+  `src/ncp_langgraph/_version.py`, `tests/test_smoke.py`, and
+  `python/ncp-langgraph/CHANGELOG.md` together. Bump the package
+  version: `0.1.1` if the fix is functional (bugfix, behavior
+  change); `0.1.0.post1` if the fix is purely metadata
+  (README / classifiers / long_description that doesn't change
+  wheel contents semantically). All three version sources MUST move
+  in lockstep -- the version-parity guard in pre-flight catches
+  drift before publish but not silently retag-then-publish.
+- After the PR merges, rebuild from scratch:
+  `rm -rf dist/ && python -m build`.
+- Upload the NEW version to TestPyPI for a fresh rehearsal.
+- Do NOT push the broken `0.1.0` to real PyPI. The real-PyPI publish
+  should use the same NEW version number that succeeded on TestPyPI.
+
+When you reach a clean rehearsal under the new version, retag with
+the matching tag (`ncp-langgraph-v0.1.1` or whatever the new version
+is) and proceed to ceremony step 5+ with that new version.
+
+### PyPI publishing credentials (first-publish bootstrap)
+
+For v0.1.0 (the **first** publish of `ncp-langgraph`), the PyPI
+project does NOT yet exist. This rules out project-scoped tokens
+(they require an existing project) and rules out a long-lived
+project-scoped token created before publish. Two viable paths:
+
+- **Preferred (long-term):** [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/)
+  via GitHub Actions OIDC. Supports pending publishers for new
+  projects. Issues short-lived API tokens automatically per run.
+  Set this up for v0.2.0+; configuring it for v0.1.0 adds a CI
+  workflow that PR F does not include in scope.
+- **Manual first-publish (v0.1.0 path):** use a one-time
+  **account-scoped** PyPI API token, revoke it immediately after
+  publish. Once the project exists, create **project-scoped**
+  credentials (or migrate to Trusted Publishing) for v0.2.0+.
+
+Same discipline applies to TestPyPI: account-scoped token for the
+first upload, revoke after, switch to project-scoped or Trusted
+Publishing once the project exists.
+
+### Release ceremony
+
+1. **RC tag and release-commit capture.** From clean `main`:
+   ```bash
+   git tag -s ncp-langgraph-v0.1.0-rc.1 -m "ncp-langgraph v0.1.0 release candidate"
+   git push origin ncp-langgraph-v0.1.0-rc.1
+
+   # Pin the exact commit being released. `git tag -s` creates an
+   # annotated tag object; bare `git rev-parse <tag>` would return
+   # the tag object's SHA, not the commit it points at. `^{commit}`
+   # dereferences to the commit so $RELEASE_COMMIT is guaranteed to
+   # be a commit SHA (which step 6 needs when it creates the real
+   # tag at this commit, even if main advances).
+   RELEASE_COMMIT="$(git rev-parse ncp-langgraph-v0.1.0-rc.1^{commit})"
+   echo "RELEASE_COMMIT=$RELEASE_COMMIT"
+   ```
+
+2. **Verify NO runtime workflows fire.** Success signal of the
+   tag-pattern discipline. Check each runtime workflow specifically
+   so unrelated CI activity can't hide the wrong-tag signal:
+   ```bash
+   gh run list --workflow release.yml --limit 10
+   gh run list --workflow docker.yml --limit 10
+   ```
+   No runs should appear for the RC tag (`ncp-langgraph-v0.1.0-rc.1`)
+   or for `$RELEASE_COMMIT`. If any runtime workflow fires: **STOP**
+   -- the tag pattern was wrong. Abort the publish, delete the tag,
+   fix the pattern, and re-tag with the correct `ncp-langgraph-v*`
+   form before retrying.
+
+3. **Build the RC against the tagged commit** (not `main`, which may
+   have advanced) and upload to TestPyPI. **Stay on the tag through
+   verification (step 4)**; do NOT `git checkout main` between this
+   step and step 5:
+   ```bash
+   git fetch --tags origin
+   git checkout ncp-langgraph-v0.1.0-rc.1
+   cd python/ncp-langgraph
+   rm -rf dist/
+   python -m build
+   python -m twine check dist/*
+   python -m twine upload --repository testpypi dist/*
+   cd ../..
+   ```
+
+   **Note on version numbers:** the package version stays `0.1.0` for
+   both the RC and real-tag paths. The `-rc.1` label is the GIT TAG
+   suffix, not the package version. TestPyPI and PyPI are separate
+   indexes -- uploading `ncp-langgraph 0.1.0` to TestPyPI does NOT
+   prevent uploading `ncp-langgraph 0.1.0` to real PyPI later. Do
+   NOT add an `rc1` suffix to the package version itself.
+
+4. **TestPyPI verification** from a clean venv (still on the RC tag
+   from step 3). Install runtime dependencies from real PyPI FIRST,
+   then `--no-deps` install the `ncp-langgraph` wheel from TestPyPI.
+   This proves the TestPyPI wheel installs while keeping dependency
+   resolution scoped to real PyPI (avoids the dependency-confusion
+   hazard of `--extra-index-url`):
+   ```bash
+   python -m venv /tmp/ncp-lg-rc
+   /tmp/ncp-lg-rc/bin/python -m pip install --upgrade pip
+   /tmp/ncp-lg-rc/bin/python -m pip install "langgraph>=1.0.0,<2.0.0"
+   /tmp/ncp-lg-rc/bin/python -m pip install \
+     --index-url https://test.pypi.org/simple/ \
+     --no-deps \
+     ncp-langgraph==0.1.0
+   # Then run examples/langgraph/lead_qualification_agent.py against
+   # a real ncp-mcp-server install on PATH. The example script we
+   # run lives at the RC commit, which matches the wheel we just
+   # uploaded:
+   cargo install ncp-mcp-server --version 0.1.0 --locked
+   /tmp/ncp-lg-rc/bin/python examples/langgraph/lead_qualification_agent.py
+   ```
+
+   Expected: example runs to completion with a `Success` `result_type`
+   in the printed state. If this step FAILS, see the immutability
+   warning above and fix-forward with a version bump.
+
+5. **Return to main and clean the RC tag** (no GitHub Release to
+   delete; no GHCR images):
+   ```bash
+   git checkout main
+   git push origin --delete ncp-langgraph-v0.1.0-rc.1
+   git tag -d ncp-langgraph-v0.1.0-rc.1
+   ```
+   TestPyPI artifacts are immutable but ignored once real PyPI carries
+   the canonical 0.1.0.
+
+6. **Create the real tag at the captured release commit.** Pointing
+   at `$RELEASE_COMMIT` (not `main` HEAD) guarantees the real tag is
+   the same commit that the RC tested, even if `main` has advanced:
+   ```bash
+   git tag -s ncp-langgraph-v0.1.0 "$RELEASE_COMMIT" -m "ncp-langgraph v0.1.0"
+   git push origin ncp-langgraph-v0.1.0
+   ```
+
+7. **Again verify NO runtime workflows fire** for the real tag.
+   Same per-workflow check as step 2:
+   ```bash
+   gh run list --workflow release.yml --limit 10
+   gh run list --workflow docker.yml --limit 10
+   ```
+   No runs should appear for `ncp-langgraph-v0.1.0` or for
+   `$RELEASE_COMMIT`. Same STOP condition as step 2.
+
+8. **Publish to real PyPI.** Use the first-publish token approach
+   from the credentials section above (account-scoped, revoke
+   immediately after publish).
+
+   Build + publish against the tagged commit. **Stay on the tag
+   through verification (step 9)**:
+   ```bash
+   git checkout ncp-langgraph-v0.1.0
+   cd python/ncp-langgraph
+   rm -rf dist/
+   python -m build
+   python -m twine upload dist/*
+   cd ../..
+   ```
+
+9. **Post-publish verification** (still on the real tag from step 8).
+
+   Visit, in a browser:
+   - https://pypi.org/project/ncp-langgraph/0.1.0/ -- README renders,
+     no broken links
+   - https://pypi.org/project/ncp-langgraph/ -- package page shows
+     v0.1.0 as latest
+
+   Clean-venv install from a fresh toolchain:
+   ```bash
+   python -m venv /tmp/ncp-lg-verify
+   /tmp/ncp-lg-verify/bin/python -m pip install --no-cache-dir ncp-langgraph==0.1.0
+   ```
+
+   Then run `examples/langgraph/lead_qualification_agent.py`
+   end-to-end against a real `cargo install ncp-mcp-server` binary on
+   `PATH`. The example script we run lives at the real-tag commit,
+   which matches the wheel just published.
+
+10. **Return to main:**
+    ```bash
+    git checkout main
+    ```
+
+11. **Merge PR G immediately.** Per the no-stale-window discipline,
+    PR G was drafted, CI-green, and review-approved BEFORE this
+    ceremony started (between PR F's merge and step 1's RC tag push).
+    Now that the post-publish verification (step 9) confirms
+    `pip install ncp-langgraph==0.1.0` works, click merge on PR G.
+    Front-door docs are now consistent with PyPI within minutes of
+    publish, not hours/days.
+
+12. **Governance closure (out-of-band).** After PR G merges, add
+    `langgraph-test` to the required-check set per
+    `docs/BRANCH_PROTECTION.md` "Adding new required checks". This
+    is the final step that fully closes Phase 3A.3.
+
+### Scope
+
+This publishes **`ncp-langgraph` only**, to PyPI. No GitHub Release
+artifacts, no GHCR Docker image, no Zenodo archive. Matches the
+`ncp-mcp-server` adapter publish scope.

--- a/python/ncp-langgraph/CHANGELOG.md
+++ b/python/ncp-langgraph/CHANGELOG.md
@@ -13,31 +13,91 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `ncp-langgraph` is versioned independently from `ncp-runtime` and
 `ncp-mcp-server`; bumps reflect adapter API or behavior changes only.
 
-## [Unreleased]
+## [0.1.0] - 2026-05-29
+
+First public release. Publishes the LangGraph adapter for the Neural
+Computation Protocol to PyPI.
 
 ### Added
 
-- Package skeleton (`pyproject.toml`, src-layout, hatchling backend).
-- Public API surface stubs: `NCPNode`, `NCPNode.from_subprocess(...)`,
-  `call_ncp_graph(...)`, `RunnerResult` dataclass, and exception
-  hierarchy (`NCPError`, `NCPSubprocessError`, `NCPInvocationError`,
-  `NCPTimeoutError`, `NCPAmbiguousToolError`). Executable API paths
-  (`NCPNode.from_subprocess(...)`, `NCPNode.__call__(...)`, and
-  `call_ncp_graph(...)`) raise `NotImplementedError` until PR C and
-  PR D land the implementations.
-- PEP 561 `py.typed` marker so type-checkers consume the package's
-  inline type information.
-- Build/lint/test tooling: `ruff` (lint + format), `mypy --strict` over
-  `src/`, `pytest`. Available via `pip install -e .[dev]`.
-- `langgraph-test` CI job in `.github/workflows/rust.yml` (advisory
-  until Phase 3A.3 PR G merges).
+- **`NCPNode`** -- LangGraph-callable wrapper around an `ncp-mcp-server`
+  graph. Locked classmethod factory `NCPNode.from_subprocess(...)`
+  returns a callable instance that registers as a LangGraph node via
+  `builder.add_node(name, instance)`.
+- **`call_ncp_graph(...)`** -- lower-level function for callers that
+  want NCP from Python without LangGraph state semantics. Returns a
+  `RunnerResult` directly.
+- **`RunnerResult`** -- frozen dataclass carrying the graph's terminal
+  output, the full MCP `structuredContent`, and trace metadata
+  (`result_type`, `trace_id`, `trace_path`).
+- **Exception hierarchy** -- `NCPError` (base), `NCPSubprocessError`,
+  `NCPInvocationError` (carries `.structured_content`, `.result_type`,
+  `.trace_id`, `.trace_path`), `NCPTimeoutError`,
+  `NCPAmbiguousToolError`.
+- **State input semantics (locked design doc §4.2):** whole-state
+  pass-through by default; `input_key=...` narrows to
+  `state[input_key]`.
+- **State output semantics (locked design doc §4.1):** partial
+  state-update dict with exactly two keys (configurable `output_key`,
+  `trace_key`). Equal keys are rejected at construction with
+  `ValueError`.
+- **State immutability (locked design doc §4.4):** enforced LOCALLY in
+  `NCPNode.__call__` via `copy.deepcopy(arguments)`. Does NOT rely
+  transitively on the runner's non-mutation behavior.
+- **Subprocess runner:** spawns `ncp-mcp-server` per call, drives the
+  locked 4-frame MCP dialog (`initialize`,
+  `notifications/initialized`, `tools/list`, `tools/call`), closes
+  stdin, and asserts a clean post-dialog exit (regression sentinel
+  for the rmcp tokio time-driver panic discovered in Phase 3A.2-E).
+- **Strict JSON discipline:** `json.dumps(..., allow_nan=False)`
+  everywhere; rejects `NaN` / `Infinity` / `-Infinity` at the Python
+  boundary.
+- **Cross-platform timeout** via `threading.Timer` (not
+  `signal.SIGALRM`); works on Linux, macOS, Windows.
+- **UTF-8 stdio pinning** via `subprocess.Popen(encoding="utf-8")`;
+  MCP JSON is UTF-8 by spec.
+- **stderr captured to a tempfile** (NOT `subprocess.PIPE`) to avoid
+  the pipe-buffer deadlock hazard. Tempfile is kept on
+  `NCPSubprocessError` / `NCPTimeoutError` (diagnostic tail included
+  in exception message); deleted on success, `NCPInvocationError`,
+  and `NCPAmbiguousToolError`.
+- **Library-boundary type checks:** `arguments` must be a `dict` at
+  runtime; `tools/list` entries validated upfront; cross-check
+  between MCP `isError` and `result_type` per locked
+  `docs/MCP_ADAPTER.md` §6 truth table.
+- **PEP 561 `py.typed` marker;** `mypy --strict` clean over `src/`.
+- **Documentation:** binding design contract in
+  [`docs/LANGGRAPH_ADAPTER.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/LANGGRAPH_ADAPTER.md);
+  quick-start in this package's README; adopter example in
+  [`examples/langgraph/`](https://github.com/madeinplutofabio/neural-computation-protocol/tree/main/examples/langgraph)
+  (stubbed on `echo-pipeline` until issue
+  [#29](https://github.com/madeinplutofabio/neural-computation-protocol/issues/29)
+  ships the real lead-qualification graph).
 
-### Notes
+### Requirements
 
-- This package skeleton uses version `0.1.0.dev0` and is NOT intended
-  for end-user installation. It exists to lock the package layout,
-  build pipeline, and CI gate before implementation work begins.
-- The locked design contract for v0.1.0 lives in
-  [`docs/LANGGRAPH_ADAPTER.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/LANGGRAPH_ADAPTER.md).
+- Python 3.10+
+- `ncp-mcp-server v0.1.x` on `PATH` (separate Rust binary; install via
+  `cargo install ncp-mcp-server --version 0.1.0 --locked`). Pass an
+  absolute path via `NCPNode.from_subprocess(binary=...)` to bypass
+  `PATH`.
+- LangGraph 1.x (`langgraph>=1.0.0,<2.0.0`).
 
-[Unreleased]: https://github.com/madeinplutofabio/neural-computation-protocol/commits/main/python/ncp-langgraph
+### v0.1.0 limitations (intentional non-goals)
+
+- **Sync only.** `NCPNode.__call__` is synchronous. Native async
+  support (`NCPAsyncNode`) is a v0.2.0+ addition.
+- **One subprocess per call.** Each invocation spawns a fresh
+  `ncp-mcp-server` process. Persistent pool is a v0.2.0+ perf
+  optimization.
+- **One graph per `NCPNode` instance.** Multi-graph adapter instances
+  are a v0.2.0+ addition.
+- **Subprocess invocation only.** PyO3 direct binding and Streamable
+  HTTP transport are deferred (see
+  [`docs/LANGGRAPH_ADAPTER.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/LANGGRAPH_ADAPTER.md) §11
+  and future-work issues
+  [#34](https://github.com/madeinplutofabio/neural-computation-protocol/issues/34)
+  and
+  [#36](https://github.com/madeinplutofabio/neural-computation-protocol/issues/36)).
+
+[0.1.0]: https://pypi.org/project/ncp-langgraph/0.1.0/

--- a/python/ncp-langgraph/pyproject.toml
+++ b/python/ncp-langgraph/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ncp-langgraph"
-version = "0.1.0.dev0"
+version = "0.1.0"
 description = "LangGraph adapter for NCP: invoke NCP graphs as LangGraph nodes via ncp-mcp-server subprocess."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/ncp-langgraph/src/ncp_langgraph/_version.py
+++ b/python/ncp-langgraph/src/ncp_langgraph/_version.py
@@ -14,4 +14,4 @@ PR F bumps this from ``"0.1.0.dev0"`` to ``"0.1.0"`` as part of the
 publish ceremony (mirrors the bump in ``pyproject.toml``).
 """
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.1.0"

--- a/python/ncp-langgraph/tests/test_smoke.py
+++ b/python/ncp-langgraph/tests/test_smoke.py
@@ -30,14 +30,22 @@ def test_package_imports() -> None:
     assert ncp_langgraph.__version__ != ""
 
 
-def test_version_matches_skeleton() -> None:
-    """`__version__` is the locked v0.1.0.dev0 skeleton string.
+def test_version_matches_package_release() -> None:
+    """``__version__`` matches the locked v0.1.0 package release string
+    AND matches the installed package metadata version.
 
-    PR F flips this to ``"0.1.0"`` as part of the publish bump; this
-    assertion is the regression sentinel that prevents an accidental
-    version bump during PR B / C / D / E.
+    Regression sentinel that catches drift between the three version
+    sources: ``pyproject.toml`` (wheel metadata),
+    ``src/ncp_langgraph/_version.py`` (runtime ``__version__``), and
+    the value this assertion pins. The metadata-parity assertion in
+    particular catches the pre-publish ceremony's biggest risk: a
+    wheel whose runtime ``__version__`` disagrees with the version
+    encoded in its own metadata. CI runs this every push.
     """
-    assert ncp_langgraph.__version__ == "0.1.0.dev0"
+    import importlib.metadata as md
+
+    assert ncp_langgraph.__version__ == "0.1.0"
+    assert md.version("ncp-langgraph") == ncp_langgraph.__version__
 
 
 def test_public_surface_exports() -> None:


### PR DESCRIPTION
## Summary

PR F prepares `ncp-langgraph` for the v0.1.0 PyPI publish. The publish ceremony itself runs **out-of-band** after this PR merges AND after PR G is drafted, CI-green, and review-approved (no-stale-window discipline carried from Phase 3A.2's #27 lesson).

**Version bump (lockstep across three sources):**
- `pyproject.toml`: `0.1.0.dev0` → `0.1.0`
- `src/ncp_langgraph/_version.py`: `__version__` `0.1.0.dev0` → `0.1.0`
- `tests/test_smoke.py`: rename `test_version_matches_skeleton` → `test_version_matches_package_release`; bump assertion to `"0.1.0"`; **ALSO add metadata-parity check** via `importlib.metadata.version("ncp-langgraph")` so CI catches runtime/metadata drift (this is the regression sentinel that would have caught my first-pass miss where I only updated 1 of 3 version sources).

**CHANGELOG.md:** `[Unreleased]` → `[0.1.0] - 2026-05-29` with enumerated shipped capabilities, Requirements, and v0.1.0 limitations. Bottom anchor link points at the PyPI page.

**docs/PUBLISHING.md:** new "Python adapter publish (`ncp-langgraph`)" section mirroring the existing `ncp-mcp-server` flow with PyPI-specific adjustments:
- Tag pattern LOCKED: `ncp-langgraph-v*` (MUST NOT start with bare `v`)
- Pre-flight gates open with release-venv setup + explicit `build`+`twine` + version-parity assertion BEFORE any other gate
- TestPyPI distribution-filename immutability discipline (fix-forward via PR; no silent retag)
- First-publish credentials bootstrap (account-scoped → revoke → migrate to project-scoped or Trusted Publishing for v0.2.0+)
- `$RELEASE_COMMIT` captured with `^{commit}` dereference so the annotated RC tag's commit (not the tag object SHA) pins the real tag in step 6
- STOP-discipline workflow checks use targeted `--workflow release.yml/docker.yml` filters
- TestPyPI install uses `--no-deps` after pre-installing langgraph from real PyPI (dependency-confusion mitigation)
- Verification stays on the tagged commit through both TestPyPI and real-PyPI smokes
- Steps 10-12 encode no-stale-window discipline + governance closure (langgraph-test → required check)

See commit `58b1a5e` for the full breakdown.

## Test plan

- [x] `python -m mypy --strict src` — no issues in 5 files
- [x] `python -m ruff check .` — clean
- [x] `python -m ruff format --check .` — 9 files already formatted
- [x] `python -m pytest` — 78 passed, 4 gated skipped
- [x] `NCP_MCP_SERVER=... python -m pytest` — **82 passed** end-to-end including the new metadata-parity assertion
- [x] `python -m build` — wheel + sdist produced at version `0.1.0` (no `.dev0`)
- [x] `py.typed` present in built wheel
- [x] `python -m twine check dist/*` — **wheel + sdist both PASSED** (README + metadata render correctly for PyPI)
- [ ] CI: `langgraph-test` job goes green on this PR
- [ ] CI: existing required checks (DCO, fmt, clippy, test, mcp-smoke, validate, wasm-build) all green

## Refs

- Design contract: [`docs/LANGGRAPH_ADAPTER.md`](docs/LANGGRAPH_ADAPTER.md) (PR #40)
- Skeleton: PR #41
- Subprocess runner: PR #42
- NCPNode wrapper: PR #43
- Example + docs: PR #44
- Template: existing "Adapter publish (`ncp-mcp-server`)" section in `docs/PUBLISHING.md`
- Plan: Phase 3A.3 PR G (mandatory front-door doc sync, drafted before ceremony) remaining