### PR TITLE
docs(phase-3.A.3): finalize PyPI README for ncp-langgraph v0.1.0 (pre-publish hotfix)

### DIFF
--- a/python/ncp-langgraph/README.md
+++ b/python/ncp-langgraph/README.md
@@ -7,6 +7,7 @@
 
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
+[![PyPI](https://img.shields.io/pypi/v/ncp-langgraph.svg)](https://pypi.org/project/ncp-langgraph/)
 
 LangGraph adapter for the [Neural Computation Protocol (NCP)](https://github.com/madeinplutofabio/neural-computation-protocol).
 
@@ -71,17 +72,14 @@ against a known `ncp-mcp-server` release.
 
 ### 2. The Python adapter (this package)
 
-Until v0.1.0 is published to PyPI in Phase 3A.3 PR F, install editable
-from a workspace clone:
-
-```bash
-python -m pip install -e python/ncp-langgraph
-```
-
-After publish:
-
 ```bash
 python -m pip install ncp-langgraph
+```
+
+Or pin to a specific version for reproducibility:
+
+```bash
+python -m pip install ncp-langgraph==0.1.0
 ```
 
 `ncp-langgraph` does NOT bundle the `ncp-mcp-server` binary in v0.1.0.
@@ -109,10 +107,9 @@ pass its absolute path via `NCPNode.from_subprocess(binary=...)`.
 - **Subprocess invocation only.** PyO3 direct binding and Streamable
   HTTP transport are deferred (see
   [`docs/LANGGRAPH_ADAPTER.md`](https://github.com/madeinplutofabio/neural-computation-protocol/blob/main/docs/LANGGRAPH_ADAPTER.md) §11
-  and future-work issues
+  and future-work issue
   [#34](https://github.com/madeinplutofabio/neural-computation-protocol/issues/34)
-  and
-  [#36](https://github.com/madeinplutofabio/neural-computation-protocol/issues/36)).
+  for Streamable HTTP).
 
 ## License
 


### PR DESCRIPTION
## Summary

Pre-publish hotfix for `python/ncp-langgraph/README.md` (the PyPI
project page). This PR is carved out of PR G's scope because PyPI
renders the project page from the release-tag commit, NOT from `main`.
PR G merges AFTER the publish ceremony, so it cannot fix the PyPI
rendered README. This hotfix must merge BEFORE the ceremony tags
`ncp-langgraph-v0.1.0`.

## Sequencing (mandatory)

1. CI green on this PR.
2. Review-approve this PR.
3. **Merge this PR.**
4. Then run the PyPI publish ceremony (RC tag + TestPyPI rehearsal,
   delete RC tag, real tag `ncp-langgraph-v0.1.0`, real PyPI publish,
   post-publish verification).
5. After post-publish verification confirms `pip install ncp-langgraph==0.1.0`
   works from a clean venv, merge PR #46 (PR G front-door doc sync)
   immediately.
6. Out-of-band: add `langgraph-test` to required-check set per
   `docs/BRANCH_PROTECTION.md`.

If this PR is NOT merged before the ceremony tag, the PyPI project
page for v0.1.0 will ship with pre-publish editable-install language
and a stale `#36` issue reference. That artifact is immutable once
uploaded.

## Changes (three surgical edits, single file)

`python/ncp-langgraph/README.md`:

1. **Add PyPI version badge** to the badge row
   (`https://img.shields.io/pypi/v/ncp-langgraph.svg` linked to the
   PyPI project page). Becomes a live shields.io indicator after the
   ceremony publishes v0.1.0.
2. **Replace install §2** - drop the pre-publish editable-install
   branch (`pip install -e python/ncp-langgraph`) and the
   "After publish:" conditional. Keep only the post-publish install
   commands, with a pinned-version variant for reproducibility.
3. **Correct limitations footnote** - remove the stale `#36` reference
   from the "Subprocess invocation only" bullet. `#36` is the
   completed Phase 3A.3 LangGraph design-doc issue, NOT a future-work
   transport issue. Keep `#34` (Streamable HTTP) with a "for Streamable
   HTTP" clarifier so the remaining reference is unambiguous.

Net diff: `1 file changed, 6 insertions(+), 9 deletions(-)`.

## Stale-marker audit

Case-insensitive equivalent search over `python/ncp-langgraph/README.md`
for: `0.1.0.dev0`, editable `ncp-langgraph` installs, pre-publish
wording, in-development LangGraph wording, "Until v0.1.0 is published",
"After publish", and any reference to issue `#36` in a future-work
context.

Result: zero matches.

## Test plan

- [ ] All 11 existing required CI checks pass on this PR.
- [ ] `langgraph-test` advisory job passes on this PR.
- [ ] Manual render check on the GitHub diff: PyPI badge URL resolves;
      install commands are copy-paste correct; `#34` link resolves.
- [ ] PR is review-approved and merged BEFORE the ceremony tags
      `ncp-langgraph-v0.1.0`.

Companion to PR #46 (PR G - front-door doc sync), which merges AFTER
the publish ceremony.