### PR TITLE
ci(phase-3.A.3): switch ncp-langgraph publish to PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/publish-langgraph.yml
+++ b/.github/workflows/publish-langgraph.yml
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Fabio Marcello Salvadori
+#
+# Publish ncp-langgraph to PyPI via OIDC Trusted Publishing.
+#
+# Triggered on tags matching the Phase 3A.3 locked pattern `ncp-langgraph-v*`.
+# The `validate-tag` job enforces the exact tag form and routes:
+#
+#   - `ncp-langgraph-vX.Y.Z-rc.N` -> publish to TestPyPI (rehearsal)
+#   - `ncp-langgraph-vX.Y.Z`      -> publish to real PyPI (canonical)
+#
+# Any other tag form (e.g. `ncp-langgraph-v0.1.0-rc1` with a missing
+# dot) fails fast in `validate-tag` and NEVER reaches a publish job.
+#
+# No tokens. Uses PyPI Trusted Publishing via OIDC. Pending publishers
+# must be configured on PyPI and TestPyPI BEFORE the first tag push.
+#
+# Pending publisher settings:
+#
+#   PyPI (https://pypi.org/manage/account/publishing/)
+#     project name      : ncp-langgraph
+#     owner             : madeinplutofabio
+#     repository name   : neural-computation-protocol
+#     workflow filename : publish-langgraph.yml
+#     environment       : pypi
+#
+#   TestPyPI (https://test.pypi.org/manage/account/publishing/)
+#     project name      : ncp-langgraph
+#     owner             : madeinplutofabio
+#     repository name   : neural-computation-protocol
+#     workflow filename : publish-langgraph.yml
+#     environment       : testpypi
+#
+# Recommended GitHub environment protection rules:
+#   - `pypi`: require manual approval, so the real publish is a
+#     deliberate UI click after the RC rehearsal passes.
+#   - `testpypi`: no approval gate; RC tag pushes auto-publish.
+
+name: Publish ncp-langgraph
+
+on:
+  push:
+    tags:
+      - "ncp-langgraph-v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-ncp-langgraph-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate-tag:
+    name: Validate publish tag
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      publish_target: ${{ steps.validate.outputs.publish_target }}
+      package_version: ${{ steps.validate.outputs.package_version }}
+    steps:
+      - id: validate
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+
+          if [[ "$TAG" =~ ^ncp-langgraph-v([0-9]+\.[0-9]+\.[0-9]+)-rc\.([0-9]+)$ ]]; then
+            echo "publish_target=testpypi" >> "$GITHUB_OUTPUT"
+            echo "package_version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$TAG" =~ ^ncp-langgraph-v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "publish_target=pypi" >> "$GITHUB_OUTPUT"
+            echo "package_version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::error::Invalid ncp-langgraph publish tag: $TAG"
+          echo "::error::Expected ncp-langgraph-vX.Y.Z or ncp-langgraph-vX.Y.Z-rc.N"
+          exit 1
+
+  preflight:
+    name: Preflight (lint, type, full tests)
+    needs: validate-tag
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install package + dev extras
+        working-directory: python/ncp-langgraph
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Verify runtime/package metadata version parity
+        working-directory: python/ncp-langgraph
+        run: |
+          python - <<'PYEOF'
+          import importlib.metadata as md
+          import ncp_langgraph
+
+          assert ncp_langgraph.__version__ == "0.1.0"
+          assert md.version("ncp-langgraph") == ncp_langgraph.__version__
+          print("runtime and package metadata versions match")
+          PYEOF
+
+      - name: ruff check
+        working-directory: python/ncp-langgraph
+        run: python -m ruff check .
+
+      - name: ruff format --check
+        working-directory: python/ncp-langgraph
+        run: python -m ruff format --check .
+
+      - name: mypy --strict src
+        working-directory: python/ncp-langgraph
+        run: python -m mypy --strict src
+
+      - name: Build ncp-mcp-server for integration tests
+        run: cargo build -p ncp-mcp-server --release --locked
+
+      - name: pytest with real ncp-mcp-server binary
+        working-directory: python/ncp-langgraph
+        env:
+          NCP_MCP_SERVER: ${{ github.workspace }}/target/release/ncp-mcp-server
+        run: python -m pytest
+
+  build:
+    name: Build sdist + wheel
+    needs: [validate-tag, preflight]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install build tooling
+        working-directory: python/ncp-langgraph
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build sdist + wheel
+        working-directory: python/ncp-langgraph
+        run: |
+          rm -rf dist/
+          python -m build
+
+      - name: twine check
+        working-directory: python/ncp-langgraph
+        run: python -m twine check dist/*
+
+      - name: Verify py.typed in wheel (PEP 561)
+        working-directory: python/ncp-langgraph
+        run: |
+          python - <<'PYEOF'
+          import sys
+          import zipfile
+          from pathlib import Path
+
+          wheel = next(Path("dist").glob("*.whl"))
+          with zipfile.ZipFile(wheel) as z:
+              names = set(z.namelist())
+
+          if "ncp_langgraph/py.typed" not in names:
+              print(f"::error::py.typed missing from {wheel.name}")
+              sys.exit(1)
+
+          print(f"py.typed present in {wheel.name}")
+          PYEOF
+
+      - name: Verify tag/wheel version parity
+        working-directory: python/ncp-langgraph
+        env:
+          EXPECTED_VERSION: ${{ needs.validate-tag.outputs.package_version }}
+        run: |
+          set -euo pipefail
+
+          WHEEL_FILE="$(ls dist/*.whl)"
+          WHEEL_VERSION="$(basename "$WHEEL_FILE" | sed -E 's|ncp_langgraph-([^-]+)-.*|\1|')"
+
+          echo "Expected version: $EXPECTED_VERSION"
+          echo "Wheel version:    $WHEEL_VERSION"
+
+          if [ "$EXPECTED_VERSION" != "$WHEEL_VERSION" ]; then
+            echo "::error::Tag/wheel version mismatch: tag expects '$EXPECTED_VERSION' but wheel is '$WHEEL_VERSION'"
+            exit 1
+          fi
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: python/ncp-langgraph/dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-testpypi:
+    name: Publish to TestPyPI (RC)
+    needs: [validate-tag, build]
+    if: needs.validate-tag.outputs.publish_target == 'testpypi'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/ncp-langgraph/
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI via OIDC
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: false
+          print-hash: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [validate-tag, build]
+    if: needs.validate-tag.outputs.publish_target == 'pypi'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/project/ncp-langgraph/
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI via OIDC
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: false
+          print-hash: true

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -609,6 +609,14 @@ in the release ceremony below assume the release venv created in the
 first block is currently active.** Do NOT deactivate between
 pre-flight gates and ceremony steps.
 
+The publish workflow [`.github/workflows/publish-langgraph.yml`](../.github/workflows/publish-langgraph.yml)
+re-runs an equivalent gate set in CI before any upload happens, but
+local pre-flight is still required: the cheapest place to catch a
+metadata or tooling regression is BEFORE the tag is pushed, because
+PyPI/TestPyPI distribution filenames are permanently reserved on
+first upload (see "TestPyPI distribution-filename immutability"
+below).
+
 ```bash
 # Release venv: clean Python environment with the package's [dev]
 # extras installed so the python -m <tool> discipline below resolves
@@ -704,26 +712,48 @@ When you reach a clean rehearsal under the new version, retag with
 the matching tag (`ncp-langgraph-v0.1.1` or whatever the new version
 is) and proceed to ceremony step 5+ with that new version.
 
-### PyPI publishing credentials (first-publish bootstrap)
+### Pending publisher configuration (one-time setup)
 
-For v0.1.0 (the **first** publish of `ncp-langgraph`), the PyPI
-project does NOT yet exist. This rules out project-scoped tokens
-(they require an existing project) and rules out a long-lived
-project-scoped token created before publish. Two viable paths:
+`ncp-langgraph` publishes via **PyPI Trusted Publishing** (OIDC).
+No API tokens. Authentication happens between GitHub Actions and
+PyPI on every workflow run; nothing long-lived ever exists.
 
-- **Preferred (long-term):** [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/)
-  via GitHub Actions OIDC. Supports pending publishers for new
-  projects. Issues short-lived API tokens automatically per run.
-  Set this up for v0.2.0+; configuring it for v0.1.0 adds a CI
-  workflow that PR F does not include in scope.
-- **Manual first-publish (v0.1.0 path):** use a one-time
-  **account-scoped** PyPI API token, revoke it immediately after
-  publish. Once the project exists, create **project-scoped**
-  credentials (or migrate to Trusted Publishing) for v0.2.0+.
+The publish authority for tags matching `ncp-langgraph-v*` is the
+workflow at [`.github/workflows/publish-langgraph.yml`](../.github/workflows/publish-langgraph.yml).
+Tag -> workflow -> upload. The local pre-flight gates above are a
+pre-tag verification step, not the publish channel.
 
-Same discipline applies to TestPyPI: account-scoped token for the
-first upload, revoke after, switch to project-scoped or Trusted
-Publishing once the project exists.
+**Before the first ceremony**, configure a pending publisher on each
+index. PyPI's pending-publisher form lets you point at a project
+that does not exist yet; the first valid OIDC publish creates the
+project. **Pending publishers do NOT reserve the project name** --
+configure them close to the ceremony and run the ceremony promptly,
+or someone else could squat the name in the gap.
+
+**PyPI** (https://pypi.org/manage/account/publishing/):
+
+| Field             | Value                              |
+|-------------------|------------------------------------|
+| PyPI project name | `ncp-langgraph`                    |
+| Owner             | `madeinplutofabio`                 |
+| Repository name   | `neural-computation-protocol`      |
+| Workflow filename | `publish-langgraph.yml`            |
+| Environment       | `pypi`                             |
+
+**TestPyPI** (https://test.pypi.org/manage/account/publishing/):
+same form, identical fields except set `Environment` to `testpypi`.
+
+**Recommended environment protection rules** (configure once on
+GitHub at `Settings -> Environments`):
+
+- `pypi`: enable "Required reviewers" with yourself as the
+  reviewer. Real publishes then require a deliberate UI click after
+  the RC rehearsal passes -- a self-approve gate that prevents
+  accidental real-PyPI uploads from a stray tag push.
+- `testpypi`: no protection rules. RC tag pushes auto-publish.
+
+For all post-v0.1.0 releases, this configuration is reused; no per-
+release token rotation, no revoke discipline, no manual `twine upload`.
 
 ### Release ceremony
 
@@ -742,6 +772,13 @@ Publishing once the project exists.
    echo "RELEASE_COMMIT=$RELEASE_COMMIT"
    ```
 
+   **Note on version numbers:** the package version in
+   `python/ncp-langgraph/pyproject.toml` stays `0.1.0` for both the
+   RC and real-tag paths. The `-rc.1` suffix is the GIT TAG suffix,
+   not the package version. The publish workflow validates this by
+   stripping the RC suffix from the tag and requiring the wheel version
+   to match `0.1.0`. Do NOT change the package version to `0.1.0rc1`.
+
 2. **Verify NO runtime workflows fire.** Success signal of the
    tag-pattern discipline. Check each runtime workflow specifically
    so unrelated CI activity can't hide the wrong-tag signal:
@@ -755,30 +792,31 @@ Publishing once the project exists.
    fix the pattern, and re-tag with the correct `ncp-langgraph-v*`
    form before retrying.
 
-3. **Build the RC against the tagged commit** (not `main`, which may
-   have advanced) and upload to TestPyPI. **Stay on the tag through
-   verification (step 4)**; do NOT `git checkout main` between this
-   step and step 5:
+3. **Watch the publish workflow upload the RC to TestPyPI.** Pushing
+   the RC tag in step 1 fires the `Publish ncp-langgraph` workflow.
+   Tail it:
    ```bash
-   git fetch --tags origin
-   git checkout ncp-langgraph-v0.1.0-rc.1
-   cd python/ncp-langgraph
-   rm -rf dist/
-   python -m build
-   python -m twine check dist/*
-   python -m twine upload --repository testpypi dist/*
-   cd ../..
+   gh run list --workflow publish-langgraph.yml --limit 5
+
+   RUN_ID="$(gh run list \
+     --workflow publish-langgraph.yml \
+     --limit 1 \
+     --json databaseId \
+     --jq '.[0].databaseId')"
+
+   gh run watch "$RUN_ID" --exit-status
    ```
 
-   **Note on version numbers:** the package version stays `0.1.0` for
-   both the RC and real-tag paths. The `-rc.1` label is the GIT TAG
-   suffix, not the package version. TestPyPI and PyPI are separate
-   indexes -- uploading `ncp-langgraph 0.1.0` to TestPyPI does NOT
-   prevent uploading `ncp-langgraph 0.1.0` to real PyPI later. Do
-   NOT add an `rc1` suffix to the package version itself.
+   Job sequence: `validate-tag` -> `preflight` -> `build` ->
+   `publish-testpypi`.
 
-4. **TestPyPI verification** from a clean venv (still on the RC tag
-   from step 3). Install runtime dependencies from real PyPI FIRST,
+   If `validate-tag`, `preflight`, or `build` fails, the wheel was NOT
+   uploaded; you can fix-forward without a version bump. If
+   `publish-testpypi` fails AFTER the upload action ran successfully,
+   the filename IS reserved and you must bump.
+
+4. **TestPyPI verification** from a clean venv. Install runtime
+   dependencies from real PyPI FIRST,
    then `--no-deps` install the `ncp-langgraph` wheel from TestPyPI.
    This proves the TestPyPI wheel installs while keeping dependency
    resolution scoped to real PyPI (avoids the dependency-confusion
@@ -792,9 +830,9 @@ Publishing once the project exists.
      --no-deps \
      ncp-langgraph==0.1.0
    # Then run examples/langgraph/lead_qualification_agent.py against
-   # a real ncp-mcp-server install on PATH. The example script we
-   # run lives at the RC commit, which matches the wheel we just
-   # uploaded:
+   # a real ncp-mcp-server install on PATH. The example script lives
+   # at the release-work clone's HEAD which matches the RC commit at
+   # the moment the RC tag was pushed:
    cargo install ncp-mcp-server --version 0.1.0 --locked
    /tmp/ncp-lg-rc/bin/python examples/langgraph/lead_qualification_agent.py
    ```
@@ -803,10 +841,10 @@ Publishing once the project exists.
    in the printed state. If this step FAILS, see the immutability
    warning above and fix-forward with a version bump.
 
-5. **Return to main and clean the RC tag** (no GitHub Release to
-   delete; no GHCR images):
+5. **Clean the RC tag** (no GitHub Release to delete; no GHCR
+   images). The ceremony never checked out the RC tag locally under
+   Trusted Publishing, so there's no main checkout to return to:
    ```bash
-   git checkout main
    git push origin --delete ncp-langgraph-v0.1.0-rc.1
    git tag -d ncp-langgraph-v0.1.0-rc.1
    ```
@@ -830,22 +868,33 @@ Publishing once the project exists.
    No runs should appear for `ncp-langgraph-v0.1.0` or for
    `$RELEASE_COMMIT`. Same STOP condition as step 2.
 
-8. **Publish to real PyPI.** Use the first-publish token approach
-   from the credentials section above (account-scoped, revoke
-   immediately after publish).
-
-   Build + publish against the tagged commit. **Stay on the tag
-   through verification (step 9)**:
+8. **Watch the publish workflow upload the real release to PyPI.**
+   Pushing the real tag in step 6 fires the `Publish ncp-langgraph`
+   workflow again. Tail it:
    ```bash
-   git checkout ncp-langgraph-v0.1.0
-   cd python/ncp-langgraph
-   rm -rf dist/
-   python -m build
-   python -m twine upload dist/*
-   cd ../..
+   gh run list --workflow publish-langgraph.yml --limit 5
+
+   RUN_ID="$(gh run list \
+     --workflow publish-langgraph.yml \
+     --limit 1 \
+     --json databaseId \
+     --jq '.[0].databaseId')"
+
+   gh run watch "$RUN_ID" --exit-status
    ```
 
-9. **Post-publish verification** (still on the real tag from step 8).
+   This time the routing sends the artifact to the `publish-pypi`
+   job. If you enabled the recommended **Required reviewers**
+   protection on the `pypi` environment, the job pauses and asks
+   for approval -- go to the workflow run page in the browser,
+   review the build output (artifacts, hashes), and click
+   `Approve and deploy`. The OIDC upload to PyPI then runs.
+
+   No tokens. No manual `twine upload`. The pending publisher
+   configuration from earlier authorizes this exact workflow file
+   running in this exact repo for this exact environment.
+
+9. **Post-publish verification.**
 
    Visit, in a browser:
    - https://pypi.org/project/ncp-langgraph/0.1.0/ -- README renders,
@@ -861,12 +910,15 @@ Publishing once the project exists.
 
    Then run `examples/langgraph/lead_qualification_agent.py`
    end-to-end against a real `cargo install ncp-mcp-server` binary on
-   `PATH`. The example script we run lives at the real-tag commit,
-   which matches the wheel just published.
+   `PATH`. The example script lives at the release-work clone's HEAD
+   which matches the real-tag commit (no local tag switching needed
+   under Trusted Publishing).
 
-10. **Return to main:**
+10. **Confirm you're still on main.** Trusted Publishing means no
+    local tag checkout was required during the ceremony -- you
+    should have remained on `main` throughout. Verify:
     ```bash
-    git checkout main
+    git branch --show-current   # expect: main
     ```
 
 11. **Merge PR G immediately.** Per the no-stale-window discipline,


### PR DESCRIPTION
## Summary

Pre-ceremony plumbing PR for Phase 3A.3 v0.1.0 publish. Adds the
GitHub Actions workflow that publishes ncp-langgraph to PyPI via
OIDC Trusted Publishing, and rewrites the docs/PUBLISHING.md
"Python adapter publish (ncp-langgraph)" section to match.

No tokens. No `twine upload` from a maintainer terminal. Tag push
becomes the only publish trigger; OIDC handles auth on every run;
no long-lived secret ever exists. Replaces the locked-plan's
account-scoped-token approach now that the trade-off is clear:
a small dedicated workflow eliminates every future token-rotation
ceremony, and `pypi` environment approval gives a deliberate UI
click before any real-PyPI upload.

## Sequence (this PR must merge BEFORE the ceremony)

1. CI green on this PR.
2. Review-approve + **merge this PR.**
3. Configure pending publishers on PyPI + TestPyPI (~2 min web UI
   each; the workflow file's leading comment has the exact form
   field values).
4. (Recommended) Enable "Required reviewers" on the `pypi`
   GitHub environment so real publishes need an explicit UI click.
5. Run the ceremony from the WSL release-work clone - push RC
   tag, watch workflow, verify on TestPyPI; delete RC tag; push
   real tag, approve `pypi` deployment, verify on real PyPI.
6. Merge PR #46 (PR G) per the no-stale-window discipline.
7. Out-of-band: add `langgraph-test` to required-check set.

## Workflow shape (`.github/workflows/publish-langgraph.yml`)

5-job pipeline triggered on `ncp-langgraph-v*` tags:

| Job | Purpose | Routing |
|---|---|---|
| `validate-tag` | Regex-anchor the tag form. Output `publish_target` (`testpypi` or `pypi`) + `package_version`. | Always |
| `preflight` | ruff + ruff format + mypy --strict + version-parity guard + `cargo build -p ncp-mcp-server` + pytest with `NCP_MCP_SERVER` set. Full integration tests, not skipped-without-binary. | `needs: validate-tag` |
| `build` | sdist + wheel + twine check + py.typed (PEP 561) + tag/wheel version parity (uses `validate-tag` output, no bash regex strip). Uploads `dist/` as artifact. | `needs: [validate-tag, preflight]` |
| `publish-testpypi` | OIDC upload to TestPyPI. No environment-protection gate. | `needs: [validate-tag, build]`, `if: publish_target == 'testpypi'` |
| `publish-pypi` | OIDC upload to real PyPI. Gated by `pypi` GitHub environment if Required reviewers is enabled. | `needs: [validate-tag, build]`, `if: publish_target == 'pypi'` |

**Safety properties:**

- Malformed tags (e.g. `ncp-langgraph-v0.1.0-rc1` missing the dot)
  fail in `validate-tag` and NEVER reach a publish job.
- Permissions follow PyPA minimum-privilege: top-level
  `contents: read`; `id-token: write` ONLY on the two publish jobs.
- Concurrency group `publish-ncp-langgraph-${{ github.ref }}` with
  `cancel-in-progress: false` prevents duplicate publishes for the
  same tag.
- Build's version-parity check fails if the tag says `v0.2.0` but
  `pyproject.toml` still says `0.1.0`.

## Doc changes (`docs/PUBLISHING.md`)

All edits within the "Python adapter publish (`ncp-langgraph`)"
section. Runtime ceremony, MCP adapter ceremony, and all other
sections are untouched.

- **Pre-flight gates intro:** add paragraph noting the workflow
  re-runs an equivalent gate set in CI, but local pre-flight stays
  mandatory (cheapest place to catch a regression before the tag
  push, because PyPI filenames are immutable on first upload).
- **PyPI publishing credentials section** replaced by **Pending
  publisher configuration** section: pending-publisher form tables
  for PyPI + TestPyPI, recommended `pypi` Required-reviewers gate,
  and the no-name-reservation warning ("configure close to the
  ceremony and run the ceremony promptly").
- **Step 1:** version-numbers note inserted after the RC tag
  command block - right where the human might be tempted to make
  the package version `0.1.0rc1`. The workflow validates this, but
  the doc prevents the mistake at the source.
- **Step 3:** local `git checkout RC-tag` + `python -m build` +
  `twine upload --repository testpypi` replaced with `gh run list`
  + `gh run watch --exit-status` (the previous `gh run watch
  --workflow` form was invalid - that flag exists on `gh run list`
  only).
- **Step 4:** drop "still on the RC tag from step 3" wording (no
  local tag switching under TP).
- **Step 5:** rename "Return to main and clean the RC tag" to
  "Clean the RC tag"; drop the now-redundant `git checkout main`.
- **Step 8:** local `git checkout real-tag` + `twine upload`
  replaced with the same `gh run` watch idiom; note the routing
  may pause for `pypi` environment approval.
- **Step 9:** drop "still on the real tag" wording; update example
  comment.
- **Step 10:** rename "Return to main" to "Confirm you're still on
  main" with a `git branch --show-current` sanity check.

## What this PR does NOT touch

- PR #46 (PR G front-door doc sync) - unchanged; still merges
  AFTER the ceremony.
- `python/ncp-langgraph/` source, tests, or `pyproject.toml` -
  version stays `0.1.0`, no metadata churn.
- `python/ncp-langgraph/CHANGELOG.md` - the v0.1.0 entry from PR
  F is accurate as-is.
- `README.md`, `docs/ADOPTION_GUIDE.md`, `docs/ROADMAP.md`,
  `docs/INSTALL.md`, `docs/LANGGRAPH_ADAPTER.md` - none mention
  publish mechanism; nothing to update.
- Runtime/MCP-adapter ceremony sections of `docs/PUBLISHING.md` -
  untouched.

## Test plan

- [ ] All 11 existing required CI checks pass.
- [ ] `langgraph-test` advisory job passes.
- [ ] The new `publish-langgraph.yml` workflow does NOT trigger
      on this PR (it's tag-only). Visible only as a YAML diff.
- [ ] Manual render check on the workflow file: shields/badges
      not relevant; the leading comment block reads cleanly with
      the pending-publisher form values inline.
- [ ] Manual render check on `docs/PUBLISHING.md` - the new
      Pending publisher configuration table renders, step 1's
      version-numbers note is visually distinct from the bash
      block, step 3 and step 8 fenced code blocks close cleanly.

## After this PR merges

- Configure pending publishers (PyPI + TestPyPI) using the table
  values in the workflow's leading comment.
- Optionally enable Required reviewers on the `pypi` environment.
- Run the publish ceremony per the updated
  `docs/PUBLISHING.md` "Release ceremony" section.