### PR TITLE
docs(phase-3.A.3): demote ncp-langgraph pre-flight from gate to recommended sanity check (PR I)

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -601,21 +601,27 @@ the same reason.
 | `ncp-mcp-server` | `ncp-mcp-server-v0.1.0`, `ncp-mcp-server-v0.1.0-rc.1`, etc. | **None** (correct -- crates.io-first) |
 | `ncp-langgraph` | `ncp-langgraph-v0.1.0`, `ncp-langgraph-v0.1.0-rc.1`, etc. | **None** (correct -- PyPI-first) |
 
-### Pre-flight gates (required from clean main)
-
-From an up-to-date `main` checkout, against the version PR F bumped to
-(`0.1.0`). **All `python -m <tool>` invocations in this section and
-in the release ceremony below assume the release venv created in the
-first block is currently active.** Do NOT deactivate between
-pre-flight gates and ceremony steps.
+### Pre-flight sanity check (recommended before tagging)
 
 The publish workflow [`.github/workflows/publish-langgraph.yml`](../.github/workflows/publish-langgraph.yml)
-re-runs an equivalent gate set in CI before any upload happens, but
-local pre-flight is still required: the cheapest place to catch a
-metadata or tooling regression is BEFORE the tag is pushed, because
-PyPI/TestPyPI distribution filenames are permanently reserved on
-first upload (see "TestPyPI distribution-filename immutability"
-below).
+is the publish authority: it re-runs the same gate set (version
+parity + ruff + ruff format + mypy --strict + integration tests
+against a real `ncp-mcp-server` binary + twine check + py.typed
+PEP 561 marker + tag/wheel version parity) and refuses to upload
+if any gate fails. **The local block below is NOT the publish gate.**
+
+Running it before tagging is recommended (catches regressions
+earlier and cheaper than waiting for the CI cycle), but skipping it
+is acceptable -- CI will block any actual publish on a regression.
+You cannot, however, replace a successfully uploaded broken wheel
+under the same version because PyPI/TestPyPI distribution filenames
+are permanently reserved on first upload (see "TestPyPI distribution-
+filename immutability" below).
+
+From an up-to-date `main` checkout, against the version PR F bumped
+to (`0.1.0`). **All `python -m <tool>` invocations in this section
+assume the release venv created in the first block is currently
+active.**
 
 ```bash
 # Release venv: clean Python environment with the package's [dev]
@@ -673,10 +679,11 @@ python -m twine check dist/*
 cd ../..
 ```
 
-All must exit 0. `python -m twine check` is the PyPI-rendering analog
-of the crates.io README link audit in §3.1; it validates `README.md`
-will render correctly on the PyPI landing page and that the wheel +
-sdist metadata are well-formed.
+If you run this sanity check, all commands must exit 0. `python -m
+twine check` is the PyPI-rendering analog of the crates.io README
+link audit in §3.1; it validates `README.md` will render correctly
+on the PyPI landing page and that the wheel + sdist metadata are
+well-formed.
 
 ### TestPyPI distribution-filename immutability (CRITICAL)
 


### PR DESCRIPTION
## Summary

Final follow-up of Phase 3A.3. Reword the "Python adapter publish
(ncp-langgraph)" section of `docs/PUBLISHING.md` to reflect the
reality established by PR #48 (Trusted Publishing): the publish
workflow is the publish authority; local pre-flight is a recommended
sanity check, not a hard prerequisite.

Two surgical edits, one file. Bash command block byte-identical.

## Changes

- Heading: "Pre-flight gates (required from clean main)" -> "Pre-flight
  sanity check (recommended before tagging)".
- Intro reordered to lead with "the workflow is the publish authority"
  and state explicitly "The local block below is NOT the publish gate."
  Wording softened from "still required" to "recommended; skipping is
  acceptable -- CI will block any regression."
- Immutability warning tightened: "cannot replace a successfully
  uploaded broken wheel under the same version" (more precise than
  the previous "cannot recover from a successful upload" -- the real
  recovery is fix-forward with a version bump, documented in the
  next subsection).
- Closing wording shifted to "If you run this sanity check, all
  commands must exit 0..." matching the optional framing.

## Out of scope

- Bash command block (lines 620-674): byte-identical.
- Pending publisher configuration, release ceremony, TestPyPI
  distribution-filename immutability subsection: untouched.
- Runtime ceremony + MCP adapter ceremony sections: untouched.
- No source, no tests, no workflow, no version metadata, no other docs.

## Test plan

- [ ] All 12 required CI checks pass (including the newly required
      `langgraph-test`).
- [ ] Manual render check on the GitHub diff: section heading
      change reads cleanly, paragraph order makes sense, no broken
      fences.

## After this merges

Phase 3A.3 is officially complete:
- `ncp-langgraph v0.1.0` is live on PyPI
- Trusted Publishing wired for all future releases
- Front-door docs accurate
- `langgraph-test` in the required-check set
- `docs/PUBLISHING.md` accurately reflects the publish-via-workflow reality

No further follow-ups queued.