### PR TITLE
docs(readme): polish architecture diagram (drop version pins, add LangGraph path, soften wording)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Instead of “LLM for everything”, you build a graph that:
 
 ```mermaid
 flowchart LR
-  Host["MCP-compatible host"] -->|tools/call| Server["ncp-mcp-server v0.1.0"]
-  Server -->|dispatches graph| Runtime["ncp-runtime v0.3.6"]
+  Host["MCP-compatible host"] -->|tools/call| Server["ncp-mcp-server"]
+  LangGraph["LangGraph (Python via ncp-langgraph)"] -->|spawns over stdio| Server
+  Server -->|invokes| Runtime["ncp-runtime"]
   Manifest["Graph Manifest"] --> Runtime
   Runtime -->|executes| BrickA["Brick (WASM)"]
   Runtime -->|executes| BrickB["Brick (WASM)"]


### PR DESCRIPTION
## Summary

Three surgical edits to the Mermaid diagram added by #50 (which
closed #3, thanks @xzlknr). Diagram structure preserved; only
labels and one edge label change.

## Changes (single hunk, +3 / -2 in README.md)

1. **Drop hardcoded version numbers** from node labels:
   - `ncp-mcp-server v0.1.0` -> `ncp-mcp-server`
   - `ncp-runtime v0.3.6`    -> `ncp-runtime`

   Avoids a doc-bump trap on every runtime/adapter release. Live
   versions are already shown via shields.io badges at the top of
   the README.

2. **Add the LangGraph adopter path** (shipped today as part of
   Phase 3A.3 - PR #46 added the `Use NCP from LangGraph (Python)`
   section but the diagram still only showed the MCP-host path):
   ```
   LangGraph["LangGraph (Python via ncp-langgraph)"] -->|spawns over stdio| Server
   ```
   Both adopter paths now converge at `ncp-mcp-server`, which
   matches reality: `ncp-langgraph`'s `NCPNode.from_subprocess`
   spawns the same binary an MCP host would call.

3. **Soften the Server -> Runtime edge label**: `dispatches graph`
   -> `invokes`. `ncp-mcp-server` embeds `ncp-runtime` as a Cargo
   library dependency, not as a separate process. "dispatches
   graph" implied an IPC boundary that doesn't exist; "invokes" is
   accurate for a conceptual diagram without going full subgraph.

## Out of scope

- Diagram block structure: preserved as @xzlknr designed it.
- Adjacent prose, table, badges, all other README content: untouched.
- Anything else in the repo.

## Test plan

- [ ] All 12 required CI checks pass.
- [ ] GitHub Mermaid render preview on the PR diff shows the
      updated diagram correctly (one extra node, no version
      numbers, "invokes" label).

## Note

This is post-Phase-3A.3 chore-scope cleanup, not a phase
deliverable. Builds on #50's structural work.